### PR TITLE
Add --dry-run to DE CLI, fix docs for v0.7.0 API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,11 +35,11 @@ jobs:
     
     - name: Test with pytest and generate coverage report
       run: |
-        pytest --cov=kompot --cov-report=xml
+        pytest --cov=kompot --cov-report=xml --cov-report=term-missing:skip-covered
     
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### New features
+
+ - **`--dry-run` flag for `kompot de` CLI**: estimates memory, disk, and output field requirements without running the analysis. Outputs machine-parseable JSON to stdout and a human-readable report to stderr. Exit code reflects feasibility.
+ - **`kompot.configure_logging(stream)`**: reconfigure the kompot logger output stream. The CLI now logs to stderr by default, keeping stdout clean for machine-parseable output (dry-run JSON, table output).
+
+### Improvements
+
+ - **CLI logs to stderr**: all `kompot` CLI commands now write log messages to stderr instead of stdout, so stdout is reserved for data output.
+ - **`kompot smooth` documented in CLI guide**: added full command reference, options, and examples to the Sphinx CLI docs.
+ - Fix double-backslash rendering in all CLI doc code blocks.
+ - Exclude deprecated `compute_differential_*` functions from Sphinx automodule output.
+ - Add `smooth_expression()` module to Sphinx API docs.
+ - Add `RunInfo.to_settings()` and `call_args()` to documented members.
+ - Fix "Gene Expression Imputation" → "Gene Expression Smoothing" in docs toctree.
+
 ## [0.7.0] - 2026-04-13
 
 ### Breaking changes

--- a/docs/source/anndata.rst
+++ b/docs/source/anndata.rst
@@ -22,6 +22,7 @@ Differential Abundance
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: compute_differential_abundance
 
 Differential Expression
 -----------------------
@@ -30,6 +31,16 @@ Differential Expression
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: compute_differential_expression
+
+Smooth Expression
+-----------------
+
+.. automodule:: kompot.anndata.smooth
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: compute_smoothed_expression
 
 Resource Estimation
 -------------------
@@ -71,7 +82,7 @@ Utilities
 ---------
 
 .. autoclass:: kompot.anndata.utils.RunInfo
-   :members: __init__, get_summary, get_data, compare_with
+   :members: __init__, get_summary, get_data, compare_with, to_settings, call_args
    :show-inheritance:
 
 Cleanup Utilities

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -40,9 +40,6 @@ All commands support:
 Quick Start
 -----------
 
-Complete Workflow
-^^^^^^^^^^^^^^^^^
-
 .. code-block:: bash
 
    # 1. Compute diffusion maps (preprocessing)
@@ -54,54 +51,18 @@ Complete Workflow
    kompot de input_with_dm.h5ad -o de_results.h5ad \
      --groupby condition \
      --condition1 control \
-     --condition2 treatment \
-     --obsm-key DM_EigenVectors
+     --condition2 treatment
 
    # 3. Run differential abundance
    kompot da input_with_dm.h5ad -o da_results.h5ad \
      --groupby condition \
      --condition1 control \
-     --condition2 treatment \
-     --obsm-key DM_EigenVectors
+     --condition2 treatment
 
    # 4. Smooth gene expression for a single condition
    kompot smooth input_with_dm.h5ad -o smoothed.h5ad \
      --groupby condition \
-     --condition treatment \
-     --obsm-key DM_EigenVectors
-
-Diffusion Maps (Preprocessing)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: bash
-
-   kompot dm input.h5ad -o output.h5ad \
-     --pca-key X_pca \
-     --n-components 10 \
-     --knn 30
-
-Differential Expression (Basic)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: bash
-
-   kompot de input.h5ad -o output.h5ad \
-     --groupby condition \
-     --condition1 control \
-     --condition2 treatment \
-     --obsm-key X_pca \
-     --layer logged_counts
-
-Differential Abundance (Basic)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: bash
-
-   kompot da input.h5ad -o output.h5ad \
-     --groupby condition \
-     --condition1 control \
-     --condition2 treatment \
-     --obsm-key X_pca
+     --condition treatment
 
 Using Config Files
 ^^^^^^^^^^^^^^^^^^

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -24,11 +24,12 @@ Verify installation:
 Overview
 --------
 
-The CLI provides three main commands:
+The CLI provides four main commands:
 
 - ``kompot dm`` - Compute diffusion maps (preprocessing with Palantir)
 - ``kompot de`` - Differential expression analysis
 - ``kompot da`` - Differential abundance analysis
+- ``kompot smooth`` - Smooth gene expression for a single condition
 
 All commands support:
 
@@ -45,22 +46,28 @@ Complete Workflow
 .. code-block:: bash
 
    # 1. Compute diffusion maps (preprocessing)
-   kompot dm input.h5ad -o input_with_dm.h5ad \\
-     --pca-key X_pca \\
+   kompot dm input.h5ad -o input_with_dm.h5ad \
+     --pca-key X_pca \
      --n-components 10
 
    # 2. Run differential expression
-   kompot de input_with_dm.h5ad -o de_results.h5ad \\
-     --groupby condition \\
-     --condition1 control \\
-     --condition2 treatment \\
+   kompot de input_with_dm.h5ad -o de_results.h5ad \
+     --groupby condition \
+     --condition1 control \
+     --condition2 treatment \
      --obsm-key DM_EigenVectors
 
    # 3. Run differential abundance
-   kompot da input_with_dm.h5ad -o da_results.h5ad \\
-     --groupby condition \\
-     --condition1 control \\
-     --condition2 treatment \\
+   kompot da input_with_dm.h5ad -o da_results.h5ad \
+     --groupby condition \
+     --condition1 control \
+     --condition2 treatment \
+     --obsm-key DM_EigenVectors
+
+   # 4. Smooth gene expression for a single condition
+   kompot smooth input_with_dm.h5ad -o smoothed.h5ad \
+     --groupby condition \
+     --condition treatment \
      --obsm-key DM_EigenVectors
 
 Diffusion Maps (Preprocessing)
@@ -68,9 +75,9 @@ Diffusion Maps (Preprocessing)
 
 .. code-block:: bash
 
-   kompot dm input.h5ad -o output.h5ad \\
-     --pca-key X_pca \\
-     --n-components 10 \\
+   kompot dm input.h5ad -o output.h5ad \
+     --pca-key X_pca \
+     --n-components 10 \
      --knn 30
 
 Differential Expression (Basic)
@@ -78,11 +85,11 @@ Differential Expression (Basic)
 
 .. code-block:: bash
 
-   kompot de input.h5ad -o output.h5ad \\
-     --groupby condition \\
-     --condition1 control \\
-     --condition2 treatment \\
-     --obsm-key X_pca \\
+   kompot de input.h5ad -o output.h5ad \
+     --groupby condition \
+     --condition1 control \
+     --condition2 treatment \
+     --obsm-key X_pca \
      --layer logged_counts
 
 Differential Abundance (Basic)
@@ -90,10 +97,10 @@ Differential Abundance (Basic)
 
 .. code-block:: bash
 
-   kompot da input.h5ad -o output.h5ad \\
-     --groupby condition \\
-     --condition1 control \\
-     --condition2 treatment \\
+   kompot da input.h5ad -o output.h5ad \
+     --groupby condition \
+     --condition1 control \
+     --condition2 treatment \
      --obsm-key X_pca
 
 Using Config Files
@@ -104,9 +111,9 @@ For complex analyses with many parameters, use config files:
 .. code-block:: bash
 
    # Get template (copy from installed package)
-   python -c "from pathlib import Path; import shutil; \\
-   import kompot; \\
-   src = Path(kompot.__file__).parent / 'cli' / 'templates' / 'de_config_minimal.yaml'; \\
+   python -c "from pathlib import Path; import shutil; \
+   import kompot; \
+   src = Path(kompot.__file__).parent / 'cli' / 'templates' / 'de_config_minimal.yaml'; \
    shutil.copy(src, 'my_de_config.yaml')"
 
    # Edit config file
@@ -119,8 +126,8 @@ CLI arguments override config file values:
 
 .. code-block:: bash
 
-   kompot de input.h5ad -o output.h5ad \\
-     -c my_config.yaml \\
+   kompot de input.h5ad -o output.h5ad \
+     -c my_config.yaml \
      --batch-size 50  # Overrides batch_size in config
 
 Diffusion Maps Command
@@ -165,16 +172,16 @@ Example: Complete Preprocessing
 .. code-block:: bash
 
    # Starting with raw AnnData (assuming PCA already computed)
-   kompot dm bone_marrow.h5ad -o bone_marrow_dm.h5ad \\
-     --pca-key X_pca \\
-     --n-components 10 \\
+   kompot dm bone_marrow.h5ad -o bone_marrow_dm.h5ad \
+     --pca-key X_pca \
+     --n-components 10 \
      --knn 30
 
    # Then run differential analysis
-   kompot de bone_marrow_dm.h5ad -o results.h5ad \\
-     --groupby Age \\
-     --condition1 Young \\
-     --condition2 Old \\
+   kompot de bone_marrow_dm.h5ad -o results.h5ad \
+     --groupby Age \
+     --condition1 Young \
+     --condition2 Old \
      --obsm-key DM_EigenVectors
 
 Why Diffusion Maps?
@@ -267,17 +274,17 @@ Example: Complete Analysis
 
 .. code-block:: bash
 
-   kompot de bone_marrow.h5ad -o results.h5ad \\
-     --groupby Age \\
-     --condition1 Young \\
-     --condition2 Old \\
-     --obsm-key DM_EigenVectors \\
-     --layer logged_counts \\
-     --sample-col Sample \\
-     --n-landmarks 5000 \\
-     --batch-size 100 \\
-     --fdr-threshold 0.05 \\
-     --null-genes 2000 \\
+   kompot de bone_marrow.h5ad -o results.h5ad \
+     --groupby Age \
+     --condition1 Young \
+     --condition2 Old \
+     --obsm-key DM_EigenVectors \
+     --layer logged_counts \
+     --sample-col Sample \
+     --n-landmarks 5000 \
+     --batch-size 100 \
+     --fdr-threshold 0.05 \
+     --null-genes 2000 \
      --store-additional-stats
 
 Differential Abundance Command
@@ -348,15 +355,88 @@ Example: Complete Analysis
 
 .. code-block:: bash
 
-   kompot da bone_marrow.h5ad -o results.h5ad \\
-     --groupby Age \\
-     --condition1 Young \\
-     --condition2 Old \\
-     --obsm-key DM_EigenVectors \\
-     --sample-col Sample \\
-     --n-landmarks 3000 \\
-     --log-fold-change-threshold 1.0 \\
+   kompot da bone_marrow.h5ad -o results.h5ad \
+     --groupby Age \
+     --condition1 Young \
+     --condition2 Old \
+     --obsm-key DM_EigenVectors \
+     --sample-col Sample \
+     --n-landmarks 3000 \
+     --log-fold-change-threshold 1.0 \
      --ptp-threshold 0.05
+
+Smooth Command
+--------------
+
+The ``smooth`` command smooths gene expression for a single condition using GP regression. This is useful for denoising expression data or preparing smoothed expression for downstream analysis.
+
+Basic Usage
+^^^^^^^^^^^
+
+.. code-block:: bash
+
+   kompot smooth INPUT -o OUTPUT [OPTIONS]
+   kompot smooth INPUT -t TABLE_OUTPUT [OPTIONS]
+
+At least one output must be specified: ``-o/--output`` for full AnnData or ``-t/--table-output`` for CSV/TSV summary table (mean smoothed values and standard deviations per gene).
+
+Common Options
+^^^^^^^^^^^^^^
+
+.. code-block:: text
+
+   --groupby COLUMN          # Column in adata.obs with condition labels
+   --condition LABEL         # Which condition to smooth (requires --groupby)
+   --obsm-key KEY            # Cell state representation (default: DM_EigenVectors)
+   --layer LAYER             # Expression data layer (default: None, use X)
+   --result-key KEY          # Storage key (default: kompot_smooth)
+   --n-landmarks N           # Number of landmarks (default: 5000)
+   --sample-col COLUMN       # Sample ID column for sample variance estimation
+   --batch-size N            # Cells per batch (default: 500)
+   --genes GENE [GENE ...]   # Subset of genes to smooth (default: all)
+
+GP Options
+^^^^^^^^^^
+
+.. code-block:: text
+
+   --sigma FLOAT             # Noise level for the GP (default: 1.0)
+   --ls-factor FLOAT         # Length scale factor (default: 10.0)
+   --eps FLOAT               # Numerical stability constant (default: 1e-8)
+   --random-state INT        # Random seed for landmark selection
+
+Boolean Flags
+^^^^^^^^^^^^^
+
+.. code-block:: text
+
+   --use-empirical-variance  # Estimate per-gene heteroscedastic noise from GP residuals
+   --overwrite               # Overwrite existing results without warning
+   --no-progress             # Disable progress bars
+   --use-gpu                 # Use GPU acceleration (requires CUDA-enabled JAX)
+
+Example: Smooth Treatment Condition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   kompot smooth bone_marrow.h5ad -o smoothed.h5ad \
+     --groupby Age \
+     --condition Old \
+     --obsm-key DM_EigenVectors \
+     --layer logged_counts \
+     --n-landmarks 5000
+
+Example: Gene Summary Table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   kompot smooth bone_marrow.h5ad \
+     -t gene_summary.csv \
+     --groupby Age \
+     --condition Old \
+     --genes CD34 CD38 THY1
 
 Configuration Files
 -------------------
@@ -477,6 +557,7 @@ Kompot provides ready-to-use templates:
 - ``kompot/cli/templates/dm_config_template.yaml``
 - ``kompot/cli/templates/de_config_template.yaml``
 - ``kompot/cli/templates/da_config_template.yaml``
+- ``kompot/cli/templates/smooth_config_template.yaml``
 
 Pipeline Integration
 --------------------
@@ -526,20 +607,20 @@ Shell Script Example
        echo "Processing ${sample}..."
 
        # Step 1: Compute diffusion maps
-       kompot dm \\
-           data/${sample}.h5ad \\
-           -o temp/${sample}_dm.h5ad \\
-           --pca-key X_pca \\
+       kompot dm \
+           data/${sample}.h5ad \
+           -o temp/${sample}_dm.h5ad \
+           --pca-key X_pca \
            --n-components 10
 
        # Step 2: Differential expression
-       kompot de \\
-           temp/${sample}_dm.h5ad \\
-           -o results/${sample}_de.h5ad \\
-           --groupby condition \\
-           --condition1 control \\
-           --condition2 treatment \\
-           --obsm-key DM_EigenVectors \\
+       kompot de \
+           temp/${sample}_dm.h5ad \
+           -o results/${sample}_de.h5ad \
+           --groupby condition \
+           --condition1 control \
+           --condition2 treatment \
+           --obsm-key DM_EigenVectors \
            --batch-size 100
 
        if [ $? -eq 0 ]; then
@@ -695,6 +776,7 @@ Getting Help
    # Command-specific help
    kompot de --help
    kompot da --help
+   kompot smooth --help
    kompot dm --help
 
    # Check version

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -208,6 +208,7 @@ Boolean Flags
 
 .. code-block:: text
 
+   --dry-run                  # Estimate resources, print plan, exit (no analysis)
    --no-progress             # Disable progress bars
    --store-landmarks           # Store landmarks for reuse
    --store-additional-stats    # Store extra statistics
@@ -247,6 +248,33 @@ Example: Complete Analysis
      --fdr-threshold 0.05 \
      --null-genes 2000 \
      --store-additional-stats
+
+Example: Dry Run (Resource Estimation)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use ``--dry-run`` to check memory and disk requirements before committing
+to a long analysis. JSON is written to stdout (or ``-o`` file); the
+human-readable report goes to stderr.
+
+.. code-block:: bash
+
+   # Print JSON plan to stdout, human report to stderr
+   kompot de bone_marrow.h5ad --dry-run \
+     --groupby Age \
+     --condition1 Young \
+     --condition2 Old
+
+   # Save plan to a file for pipeline consumption
+   kompot de bone_marrow.h5ad --dry-run -o plan.json \
+     --groupby Age \
+     --condition1 Young \
+     --condition2 Old
+
+   # Parse in a pipeline (e.g., check feasibility before submitting a job)
+   kompot de input.h5ad --dry-run --groupby cond --condition1 A --condition2 B \
+     | jq '.feasible'
+
+The exit code is ``0`` if the plan is feasible, ``1`` if not.
 
 Differential Abundance Command
 -------------------------------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -253,26 +253,24 @@ Example: Dry Run (Resource Estimation)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use ``--dry-run`` to check memory and disk requirements before committing
-to a long analysis. JSON is written to stdout (or ``-o`` file); the
-human-readable report goes to stderr.
+to a long analysis. JSON is written to stdout; the human-readable report
+goes to stderr. Use the same arguments as the real run (``-o`` is ignored).
 
 .. code-block:: bash
 
-   # Print JSON plan to stdout, human report to stderr
+   # Check resources (human report on stderr, JSON on stdout)
    kompot de bone_marrow.h5ad --dry-run \
      --groupby Age \
      --condition1 Young \
      --condition2 Old
 
-   # Save plan to a file for pipeline consumption
-   kompot de bone_marrow.h5ad --dry-run -o plan.json \
-     --groupby Age \
-     --condition1 Young \
-     --condition2 Old
-
-   # Parse in a pipeline (e.g., check feasibility before submitting a job)
+   # Save JSON plan and check feasibility in a pipeline
    kompot de input.h5ad --dry-run --groupby cond --condition1 A --condition2 B \
-     | jq '.feasible'
+     > plan.json && echo "feasible"
+
+   # Parse specific fields with jq
+   kompot de input.h5ad --dry-run --groupby cond --condition1 A --condition2 B \
+     2>/dev/null | jq '.memory.total_human'
 
 The exit code is ``0`` if the plan is feasible, ``1`` if not.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,7 +26,7 @@
    Getting Started <notebooks/01_getting_started.ipynb>
    Advanced Differential Expression <notebooks/02_differential_expression_detailed.ipynb>
    Sample Variance Analysis <notebooks/03_sample_variance.ipynb>
-   Gene Expression Imputation <notebooks/04_expression_model.ipynb>
+   Gene Expression Smoothing <notebooks/04_expression_model.ipynb>
 
 .. |doi| image:: https://zenodo.org/badge/944121568.svg
    :target: https://zenodo.org/badge/latestdoi/944121568

--- a/kompot/__init__.py
+++ b/kompot/__init__.py
@@ -99,6 +99,23 @@ LOGGING_CONFIG = {
 logging.config.dictConfig(LOGGING_CONFIG)
 logger = logging.getLogger("kompot")
 
+
+def configure_logging(stream=None):
+    """Reconfigure the kompot logger to write to a different stream.
+
+    Parameters
+    ----------
+    stream : file-like, optional
+        Output stream for log messages. Defaults to ``sys.stdout``.
+        CLI tools typically pass ``sys.stderr`` so stdout stays clean
+        for machine-parseable output.
+    """
+    if stream is None:
+        stream = sys.stdout
+    for handler in logger.handlers:
+        if hasattr(handler, "stream"):
+            handler.stream = stream
+
 __all__ = [
     # Version
     "__version__",
@@ -122,6 +139,8 @@ __all__ = [
     "StorageSettings",
     "OutputSettings",
     "ModelSettings",
+    # Configuration
+    "configure_logging",
     # Utility functions
     "compute_mahalanobis_distance",
     "find_landmarks",

--- a/kompot/cli/de.py
+++ b/kompot/cli/de.py
@@ -1,6 +1,7 @@
 """CLI command for differential expression analysis."""
 
 import argparse
+import json
 import sys
 from pathlib import Path
 import logging
@@ -20,6 +21,19 @@ from .compute_config import configure_compute
 
 
 logger = logging.getLogger("kompot.cli")
+
+
+def _json_default(obj):
+    """JSON serializer for numpy types."""
+    import numpy as np
+
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    if isinstance(obj, (np.floating,)):
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
 def add_de_parser(subparsers) -> argparse.ArgumentParser:
@@ -165,6 +179,14 @@ def add_de_parser(subparsers) -> argparse.ArgumentParser:
         help="Estimate per-gene heteroscedastic noise from squared residuals to deflate significance for high-noise genes",
     )
 
+    # Dry run
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Estimate resource requirements and print a plan instead of running the analysis. "
+        "Outputs JSON to stdout for pipeline integration; human-readable report to stderr.",
+    )
+
     # Compute configuration
     parser.add_argument(
         "--use-gpu",
@@ -192,8 +214,8 @@ def run_de(args):
     args
         Parsed arguments from argparse
     """
-    # Validate output arguments
-    if not args.output and not args.table_output:
+    # Validate output arguments (not required for dry-run)
+    if not args.dry_run and not args.output and not args.table_output:
         logger.error("Either --output or --table-output must be specified")
         sys.exit(1)
 
@@ -245,6 +267,7 @@ def run_de(args):
             "command",
             "use_gpu",
             "threads",
+            "dry_run",
         ]
     }
 
@@ -355,23 +378,53 @@ def run_de(args):
         output_kwargs["return_full_results"] = True
     output = OutputSettings(**output_kwargs) if output_kwargs else None
 
+    # Build shared call kwargs
+    call_kwargs = dict(
+        groupby=groupby,
+        condition1=condition1,
+        condition2=condition2,
+        obsm_key=obsm_key,
+        layer=layer,
+        sample_col=sample_col,
+        gp=gp,
+        fdr=fdr,
+        filter=filter_settings,
+        storage=storage,
+        output=output,
+        **params,  # remaining params forwarded as function_kwargs
+    )
+
+    # Dry run: estimate resources, output JSON to stdout, report to stderr
+    if args.dry_run:
+        import io
+
+        try:
+            old_stdout = sys.stdout
+            sys.stdout = sys.stderr  # capture de()'s print(plan.format_report())
+            try:
+                plan = de(adata, dry_run=True, **call_kwargs)
+            finally:
+                sys.stdout = old_stdout
+        except Exception as e:
+            logger.error(f"Dry run failed: {str(e)}")
+            raise
+
+        # Machine-parseable JSON output
+        plan_dict = plan.to_dict()
+        if args.output:
+            output_path = Path(args.output)
+            with open(output_path, "w") as f:
+                json.dump(plan_dict, f, default=_json_default, indent=2)
+                f.write("\n")
+            logger.info(f"Resource plan written to {output_path}")
+        else:
+            json.dump(plan_dict, sys.stdout, default=_json_default, indent=2)
+            print(file=sys.stdout)  # trailing newline
+        sys.exit(0 if plan.is_feasible else 1)
+
     # Run analysis
     try:
-        result_dict = de(
-            adata,
-            groupby=groupby,
-            condition1=condition1,
-            condition2=condition2,
-            obsm_key=obsm_key,
-            layer=layer,
-            sample_col=sample_col,
-            gp=gp,
-            fdr=fdr,
-            filter=filter_settings,
-            storage=storage,
-            output=output,
-            **params,  # remaining params forwarded as function_kwargs
-        )
+        result_dict = de(adata, **call_kwargs)
     except Exception as e:
         logger.error(f"Analysis failed: {str(e)}")
         raise

--- a/kompot/cli/de.py
+++ b/kompot/cli/de.py
@@ -183,8 +183,8 @@ def add_de_parser(subparsers) -> argparse.ArgumentParser:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Estimate resource requirements and print a plan instead of running the analysis. "
-        "Outputs JSON to stdout for pipeline integration; human-readable report to stderr.",
+        help="Estimate resource requirements instead of running the analysis. "
+        "JSON to stdout, human-readable report to stderr. -o/--output is ignored.",
     )
 
     # Compute configuration
@@ -409,17 +409,9 @@ def run_de(args):
             logger.error(f"Dry run failed: {str(e)}")
             raise
 
-        # Machine-parseable JSON output
-        plan_dict = plan.to_dict()
-        if args.output:
-            output_path = Path(args.output)
-            with open(output_path, "w") as f:
-                json.dump(plan_dict, f, default=_json_default, indent=2)
-                f.write("\n")
-            logger.info(f"Resource plan written to {output_path}")
-        else:
-            json.dump(plan_dict, sys.stdout, default=_json_default, indent=2)
-            print(file=sys.stdout)  # trailing newline
+        # Machine-parseable JSON to stdout
+        json.dump(plan.to_dict(), sys.stdout, default=_json_default, indent=2)
+        print(file=sys.stdout)  # trailing newline
         sys.exit(0 if plan.is_feasible else 1)
 
     # Run analysis

--- a/kompot/cli/main.py
+++ b/kompot/cli/main.py
@@ -95,8 +95,12 @@ def main():
     # Parse arguments
     args = parser.parse_args()
 
-    # Setup logging
+    # Setup logging — CLI always logs to stderr so stdout stays clean
+    # for machine-parseable output (e.g., --dry-run JSON, --table-output)
     setup_logging(args.verbose)
+    from .. import configure_logging
+
+    configure_logging(stream=sys.stderr)
 
     # If no command provided, print help
     if not args.command:

--- a/kompot/resource_estimation.py
+++ b/kompot/resource_estimation.py
@@ -340,6 +340,87 @@ class ResourcePlan:
 
         return "\n".join(lines)
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the resource plan to a JSON-compatible dictionary.
+
+        Designed for machine-parseable output in CLI pipelines.
+
+        Returns
+        -------
+        dict
+            Dictionary with keys: feasible, status, memory, disk,
+            output_fields, info, warnings, errors.
+        """
+        memory_reqs = [r for r in self.requirements if r.resource_type == "memory"]
+        disk_reqs = [r for r in self.requirements if r.resource_type == "disk"]
+
+        result: Dict[str, Any] = {
+            "feasible": self.is_feasible,
+            "status": (
+                "infeasible"
+                if self.errors
+                else "warnings" if self.warnings else "ok"
+            ),
+        }
+
+        # Memory section
+        mem: Dict[str, Any] = {
+            "total_bytes": self.total_memory_required,
+            "total_human": human_readable_size(self.total_memory_required),
+        }
+        if self.availability:
+            mem["available_bytes"] = self.availability.memory_available
+            mem["available_human"] = self.availability.memory_available_human
+            mem["ratio"] = round(self.memory_ratio, 4)
+        mem["allocations"] = [
+            {
+                "name": r.name,
+                "bytes": r.size_bytes,
+                "human": r.size_human,
+                **({"shape": list(r.shape)} if r.shape else {}),
+                **({"field": r.field_name} if r.field_name else {}),
+                **({"overwrite": True} if r.overwrite else {}),
+            }
+            for r in memory_reqs
+        ]
+        result["memory"] = mem
+
+        # Disk section
+        dsk: Dict[str, Any] = {
+            "total_bytes": self.total_disk_required,
+            "total_human": human_readable_size(self.total_disk_required),
+        }
+        if self.availability:
+            dsk["available_bytes"] = self.availability.disk_available
+            dsk["available_human"] = self.availability.disk_available_human
+            dsk["path"] = self.availability.disk_path
+            dsk["ratio"] = round(self.disk_ratio, 4)
+        dsk["allocations"] = [
+            {
+                "name": r.name,
+                "bytes": r.size_bytes,
+                "human": r.size_human,
+                **({"shape": list(r.shape)} if r.shape else {}),
+                **({"overwrite": True} if r.overwrite else {}),
+            }
+            for r in disk_reqs
+        ]
+        result["disk"] = dsk
+
+        # Output fields
+        if self.output_fields:
+            result["output_fields"] = self.output_fields
+
+        # Messages
+        if self.info:
+            result["info"] = self.info
+        if self.warnings:
+            result["warnings"] = self.warnings
+        if self.errors:
+            result["errors"] = self.errors
+
+        return result
+
 
 def get_system_resources(disk_path: Optional[str] = None) -> ResourceAvailability:
     """

--- a/tests/test_cli_compute_config.py
+++ b/tests/test_cli_compute_config.py
@@ -250,6 +250,7 @@ class TestCLIDEUnitTests:
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Should exit with error
@@ -290,6 +291,7 @@ class TestCLIDEUnitTests:
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Should exit with error or raise FileNotFoundError
@@ -332,6 +334,7 @@ class TestCLIDEUnitTests:
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Should exit with error
@@ -385,6 +388,7 @@ n_landmarks: 15
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Mock compute_differential_expression to avoid actual computation
@@ -437,6 +441,7 @@ n_landmarks: 15
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Mock compute_differential_expression to return mock results
@@ -500,6 +505,7 @@ n_landmarks: 15
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Mock compute_differential_expression
@@ -555,6 +561,7 @@ n_landmarks: 15
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Mock compute_differential_expression
@@ -608,6 +615,7 @@ n_landmarks: 15
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Mock compute_differential_expression

--- a/tests/test_cli_compute_config.py
+++ b/tests/test_cli_compute_config.py
@@ -5,6 +5,8 @@ These tests directly call CLI functions to ensure coverage is captured
 (subprocess tests don't contribute to coverage).
 """
 
+import sys
+
 import pytest
 import os
 import numpy as np

--- a/tests/test_cli_compute_config.py
+++ b/tests/test_cli_compute_config.py
@@ -634,6 +634,213 @@ n_landmarks: 15
         assert exc_info.value.code == 1
 
 
+class TestCLIDryRun:
+    """Tests for the --dry-run flag on the DE CLI."""
+
+    def test_dry_run_outputs_json(self, sample_adata_for_cli, tmp_path, monkeypatch, capsys):
+        """Test that --dry-run outputs JSON to stdout and exits."""
+        from kompot.cli.de import run_de
+        import argparse
+
+        input_file = tmp_path / "input.h5ad"
+        sample_adata_for_cli.write_h5ad(input_file)
+
+        args = argparse.Namespace(
+            input=str(input_file),
+            output=str(tmp_path / "output.h5ad"),
+            table_output=None,
+            config=None,
+            groupby="condition",
+            condition1="A",
+            condition2="B",
+            obsm_key="DM_EigenVectors",
+            sample_col="sample",
+            n_landmarks=10,
+            func=None,
+            verbose=False,
+            command="de",
+            use_gpu=False,
+            threads=None,
+            layer=None,
+            result_key=None,
+            batch_size=None,
+            fdr_threshold=None,
+            null_genes=None,
+            null_seed=None,
+            no_progress=True,
+            store_landmarks=False,
+            store_additional_stats=False,
+            overwrite=False,
+            dry_run=True,
+        )
+
+        # Mock de() to return a plan object with the expected interface
+        class MockPlan:
+            is_feasible = True
+            def to_dict(self):
+                return {"feasible": True, "memory": {"total_bytes": 1024}}
+            def format_report(self):
+                return "Mock report"
+
+        def mock_de(adata, dry_run=False, **kwargs):
+            if dry_run:
+                return MockPlan()
+            return None
+
+        monkeypatch.setattr("kompot.cli.de.de", mock_de)
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_de(args)
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        import json
+        result = json.loads(captured.out)
+        assert result["feasible"] is True
+
+    def test_dry_run_infeasible_exits_1(self, sample_adata_for_cli, tmp_path, monkeypatch):
+        """Test that --dry-run exits with code 1 when plan is infeasible."""
+        from kompot.cli.de import run_de
+        import argparse
+
+        input_file = tmp_path / "input.h5ad"
+        sample_adata_for_cli.write_h5ad(input_file)
+
+        args = argparse.Namespace(
+            input=str(input_file),
+            output=str(tmp_path / "output.h5ad"),
+            table_output=None,
+            config=None,
+            groupby="condition",
+            condition1="A",
+            condition2="B",
+            obsm_key="DM_EigenVectors",
+            sample_col="sample",
+            n_landmarks=10,
+            func=None,
+            verbose=False,
+            command="de",
+            use_gpu=False,
+            threads=None,
+            layer=None,
+            result_key=None,
+            batch_size=None,
+            fdr_threshold=None,
+            null_genes=None,
+            null_seed=None,
+            no_progress=True,
+            store_landmarks=False,
+            store_additional_stats=False,
+            overwrite=False,
+            dry_run=True,
+        )
+
+        class MockPlan:
+            is_feasible = False
+            def to_dict(self):
+                return {"feasible": False}
+            def format_report(self):
+                return "Not feasible"
+
+        def mock_de(adata, dry_run=False, **kwargs):
+            if dry_run:
+                return MockPlan()
+            return None
+
+        monkeypatch.setattr("kompot.cli.de.de", mock_de)
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_de(args)
+
+        assert exc_info.value.code == 1
+
+    def test_dry_run_skips_output_validation(self, sample_adata_for_cli, tmp_path, monkeypatch):
+        """Test that --dry-run does not require --output."""
+        from kompot.cli.de import run_de
+        import argparse
+
+        input_file = tmp_path / "input.h5ad"
+        sample_adata_for_cli.write_h5ad(input_file)
+
+        args = argparse.Namespace(
+            input=str(input_file),
+            output=None,
+            table_output=None,
+            config=None,
+            groupby="condition",
+            condition1="A",
+            condition2="B",
+            obsm_key="DM_EigenVectors",
+            sample_col="sample",
+            n_landmarks=10,
+            func=None,
+            verbose=False,
+            command="de",
+            use_gpu=False,
+            threads=None,
+            layer=None,
+            result_key=None,
+            batch_size=None,
+            fdr_threshold=None,
+            null_genes=None,
+            null_seed=None,
+            no_progress=True,
+            store_landmarks=False,
+            store_additional_stats=False,
+            overwrite=False,
+            dry_run=True,
+        )
+
+        class MockPlan:
+            is_feasible = True
+            def to_dict(self):
+                return {"feasible": True}
+            def format_report(self):
+                return "OK"
+
+        def mock_de(adata, dry_run=False, **kwargs):
+            if dry_run:
+                return MockPlan()
+            return None
+
+        monkeypatch.setattr("kompot.cli.de.de", mock_de)
+
+        # Should NOT exit with "output required" error — dry-run skips that check
+        with pytest.raises(SystemExit) as exc_info:
+            run_de(args)
+
+        assert exc_info.value.code == 0
+
+
+class TestConfigureLogging:
+    """Tests for kompot.configure_logging()."""
+
+    def test_configure_logging_to_stderr(self):
+        """Test that configure_logging redirects the logger."""
+        import io
+        import kompot
+
+        buf = io.StringIO()
+        kompot.configure_logging(buf)
+
+        kompot.logger.info("test message")
+        output = buf.getvalue()
+        assert "test message" in output
+
+        # Restore default
+        kompot.configure_logging(sys.stdout)
+
+    def test_configure_logging_default_stdout(self):
+        """Test that configure_logging defaults to stdout."""
+        import kompot
+
+        kompot.configure_logging()
+        for handler in kompot.logger.handlers:
+            if hasattr(handler, "stream"):
+                assert handler.stream is sys.stdout
+                break
+
+
 class TestCLIDAUnitTests:
     """Unit tests for DA CLI functions."""
 


### PR DESCRIPTION
## Summary

- Add `--dry-run` flag to `kompot de` CLI: outputs JSON resource plan to stdout, human report to stderr
- Add `kompot.configure_logging(stream)` so CLI logs to stderr by default
- Add `kompot smooth` to CLI docs with full command reference
- Fix Sphinx docs: exclude deprecated APIs from automodule, add smooth module, update RunInfo members, fix toctree labels
- Fix double-backslash rendering in all RST code blocks
- Remove redundant Quick Start examples
- Add `[Unreleased]` changelog section

## Test plan

- [x] `kompot de --dry-run` outputs valid JSON to stdout
- [x] CLI tests pass (24/24)
- [ ] CI green
- [ ] Verify docs render on RTD