### PR TITLE
Add variance-stratified residual-Mahalanobis FDR flavor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,11 +35,11 @@ jobs:
     
     - name: Test with pytest and generate coverage report
       run: |
-        pytest --cov=kompot --cov-report=xml
+        pytest --cov=kompot --cov-report=xml --cov-report=term-missing:skip-covered
     
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### New features
 
+ - **Variance-stratified residual-Mahalanobis FDR**: opt-in FDR calibration mode that residualises `log(1 + D^2)` against a smooth function of per-gene `log_mean` and `log_var` fit on the permutation null, then applies the standard 1-D local FDR to the standardised residual. Intended for low-replication (n ≈ 2) designs where the raw Mahalanobis is dominated by per-gene variance rather than by condition. Enable with `FDRSettings(mode="variance_stratified")`. The raw `*_mahalanobis`, `*_mahalanobis_local_fdr`, and `*_is_de` columns are unchanged; additional `*_residual_mahalanobis`, `*_residual_z`, `*_residual_local_fdr`, and `*_residual_is_de` columns are written alongside. Default behaviour is unchanged. See `docs/variance_stratified_fdr.rst` for when to use it and the Tal1 chimera validation.
+ - **`kompot.residualization` module**: public helpers (`compute_gene_features`, `fit_null_trend`, `residualize_mahalanobis`, `residual_local_fdr`) for applying the correction post-hoc to any kompot output.
  - **`--dry-run` flag for `kompot de` CLI**: estimates memory, disk, and output field requirements without running the analysis. Outputs machine-parseable JSON to stdout and a human-readable report to stderr. Exit code reflects feasibility.
  - **`kompot.configure_logging(stream)`**: reconfigure the kompot logger output stream. The CLI now logs to stderr by default, keeping stdout clean for machine-parseable output (dry-run JSON, table output).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### New features
+
+ - **`--dry-run` flag for `kompot de` CLI**: estimates memory, disk, and output field requirements without running the analysis. Outputs machine-parseable JSON to stdout and a human-readable report to stderr. Exit code reflects feasibility.
+ - **`kompot.configure_logging(stream)`**: reconfigure the kompot logger output stream. The CLI now logs to stderr by default, keeping stdout clean for machine-parseable output (dry-run JSON, table output).
+
+### Improvements
+
+ - **CLI logs to stderr**: all `kompot` CLI commands now write log messages to stderr instead of stdout, so stdout is reserved for data output.
+ - **`kompot smooth` documented in CLI guide**: added full command reference, options, and examples to the Sphinx CLI docs.
+ - Fix double-backslash rendering in all CLI doc code blocks.
+ - Exclude deprecated `compute_differential_*` functions from Sphinx automodule output.
+ - Add `smooth_expression()` module to Sphinx API docs.
+ - Add `RunInfo.to_settings()` and `call_args()` to documented members.
+ - Fix "Gene Expression Imputation" → "Gene Expression Smoothing" in docs toctree.
+
 ## [0.7.0] - 2026-04-13
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ kompot.de(
     gp=GPSettings(sigma=0.5),
     fdr=FDRSettings(threshold=0.05),
 )
+
+# Variance-stratified (residual) FDR for low-replication designs (n ≈ 2):
+# residualises log(1 + D²) against a smooth surface in (log_mean, log_var)
+# fit on the permutation null, then runs the 1-D local FDR on the residual Z.
+# Adds *_residual_{mahalanobis,z,local_fdr,is_de} columns alongside the raw
+# outputs — existing behaviour is unchanged. See docs/variance_stratified_fdr.
+kompot.de(
+    adata, "condition", "WT", "Mutant",
+    fdr=FDRSettings(mode="variance_stratified"),
+)
 ```
 
 ### Command-Line Interface

--- a/docs/source/anndata.rst
+++ b/docs/source/anndata.rst
@@ -22,6 +22,7 @@ Differential Abundance
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: compute_differential_abundance
 
 Differential Expression
 -----------------------
@@ -30,6 +31,16 @@ Differential Expression
    :members:
    :undoc-members:
    :show-inheritance:
+   :exclude-members: compute_differential_expression
+
+Smooth Expression
+-----------------
+
+.. automodule:: kompot.anndata.smooth
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: compute_smoothed_expression
 
 Resource Estimation
 -------------------
@@ -71,7 +82,7 @@ Utilities
 ---------
 
 .. autoclass:: kompot.anndata.utils.RunInfo
-   :members: __init__, get_summary, get_data, compare_with
+   :members: __init__, get_summary, get_data, compare_with, to_settings, call_args
    :show-inheritance:
 
 Cleanup Utilities

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -40,9 +40,6 @@ All commands support:
 Quick Start
 -----------
 
-Complete Workflow
-^^^^^^^^^^^^^^^^^
-
 .. code-block:: bash
 
    # 1. Compute diffusion maps (preprocessing)
@@ -54,54 +51,18 @@ Complete Workflow
    kompot de input_with_dm.h5ad -o de_results.h5ad \
      --groupby condition \
      --condition1 control \
-     --condition2 treatment \
-     --obsm-key DM_EigenVectors
+     --condition2 treatment
 
    # 3. Run differential abundance
    kompot da input_with_dm.h5ad -o da_results.h5ad \
      --groupby condition \
      --condition1 control \
-     --condition2 treatment \
-     --obsm-key DM_EigenVectors
+     --condition2 treatment
 
    # 4. Smooth gene expression for a single condition
    kompot smooth input_with_dm.h5ad -o smoothed.h5ad \
      --groupby condition \
-     --condition treatment \
-     --obsm-key DM_EigenVectors
-
-Diffusion Maps (Preprocessing)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: bash
-
-   kompot dm input.h5ad -o output.h5ad \
-     --pca-key X_pca \
-     --n-components 10 \
-     --knn 30
-
-Differential Expression (Basic)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: bash
-
-   kompot de input.h5ad -o output.h5ad \
-     --groupby condition \
-     --condition1 control \
-     --condition2 treatment \
-     --obsm-key X_pca \
-     --layer logged_counts
-
-Differential Abundance (Basic)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: bash
-
-   kompot da input.h5ad -o output.h5ad \
-     --groupby condition \
-     --condition1 control \
-     --condition2 treatment \
-     --obsm-key X_pca
+     --condition treatment
 
 Using Config Files
 ^^^^^^^^^^^^^^^^^^

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -24,11 +24,12 @@ Verify installation:
 Overview
 --------
 
-The CLI provides three main commands:
+The CLI provides four main commands:
 
 - ``kompot dm`` - Compute diffusion maps (preprocessing with Palantir)
 - ``kompot de`` - Differential expression analysis
 - ``kompot da`` - Differential abundance analysis
+- ``kompot smooth`` - Smooth gene expression for a single condition
 
 All commands support:
 
@@ -45,22 +46,28 @@ Complete Workflow
 .. code-block:: bash
 
    # 1. Compute diffusion maps (preprocessing)
-   kompot dm input.h5ad -o input_with_dm.h5ad \\
-     --pca-key X_pca \\
+   kompot dm input.h5ad -o input_with_dm.h5ad \
+     --pca-key X_pca \
      --n-components 10
 
    # 2. Run differential expression
-   kompot de input_with_dm.h5ad -o de_results.h5ad \\
-     --groupby condition \\
-     --condition1 control \\
-     --condition2 treatment \\
+   kompot de input_with_dm.h5ad -o de_results.h5ad \
+     --groupby condition \
+     --condition1 control \
+     --condition2 treatment \
      --obsm-key DM_EigenVectors
 
    # 3. Run differential abundance
-   kompot da input_with_dm.h5ad -o da_results.h5ad \\
-     --groupby condition \\
-     --condition1 control \\
-     --condition2 treatment \\
+   kompot da input_with_dm.h5ad -o da_results.h5ad \
+     --groupby condition \
+     --condition1 control \
+     --condition2 treatment \
+     --obsm-key DM_EigenVectors
+
+   # 4. Smooth gene expression for a single condition
+   kompot smooth input_with_dm.h5ad -o smoothed.h5ad \
+     --groupby condition \
+     --condition treatment \
      --obsm-key DM_EigenVectors
 
 Diffusion Maps (Preprocessing)
@@ -68,9 +75,9 @@ Diffusion Maps (Preprocessing)
 
 .. code-block:: bash
 
-   kompot dm input.h5ad -o output.h5ad \\
-     --pca-key X_pca \\
-     --n-components 10 \\
+   kompot dm input.h5ad -o output.h5ad \
+     --pca-key X_pca \
+     --n-components 10 \
      --knn 30
 
 Differential Expression (Basic)
@@ -78,11 +85,11 @@ Differential Expression (Basic)
 
 .. code-block:: bash
 
-   kompot de input.h5ad -o output.h5ad \\
-     --groupby condition \\
-     --condition1 control \\
-     --condition2 treatment \\
-     --obsm-key X_pca \\
+   kompot de input.h5ad -o output.h5ad \
+     --groupby condition \
+     --condition1 control \
+     --condition2 treatment \
+     --obsm-key X_pca \
      --layer logged_counts
 
 Differential Abundance (Basic)
@@ -90,10 +97,10 @@ Differential Abundance (Basic)
 
 .. code-block:: bash
 
-   kompot da input.h5ad -o output.h5ad \\
-     --groupby condition \\
-     --condition1 control \\
-     --condition2 treatment \\
+   kompot da input.h5ad -o output.h5ad \
+     --groupby condition \
+     --condition1 control \
+     --condition2 treatment \
      --obsm-key X_pca
 
 Using Config Files
@@ -104,9 +111,9 @@ For complex analyses with many parameters, use config files:
 .. code-block:: bash
 
    # Get template (copy from installed package)
-   python -c "from pathlib import Path; import shutil; \\
-   import kompot; \\
-   src = Path(kompot.__file__).parent / 'cli' / 'templates' / 'de_config_minimal.yaml'; \\
+   python -c "from pathlib import Path; import shutil; \
+   import kompot; \
+   src = Path(kompot.__file__).parent / 'cli' / 'templates' / 'de_config_minimal.yaml'; \
    shutil.copy(src, 'my_de_config.yaml')"
 
    # Edit config file
@@ -119,8 +126,8 @@ CLI arguments override config file values:
 
 .. code-block:: bash
 
-   kompot de input.h5ad -o output.h5ad \\
-     -c my_config.yaml \\
+   kompot de input.h5ad -o output.h5ad \
+     -c my_config.yaml \
      --batch-size 50  # Overrides batch_size in config
 
 Diffusion Maps Command
@@ -165,16 +172,16 @@ Example: Complete Preprocessing
 .. code-block:: bash
 
    # Starting with raw AnnData (assuming PCA already computed)
-   kompot dm bone_marrow.h5ad -o bone_marrow_dm.h5ad \\
-     --pca-key X_pca \\
-     --n-components 10 \\
+   kompot dm bone_marrow.h5ad -o bone_marrow_dm.h5ad \
+     --pca-key X_pca \
+     --n-components 10 \
      --knn 30
 
    # Then run differential analysis
-   kompot de bone_marrow_dm.h5ad -o results.h5ad \\
-     --groupby Age \\
-     --condition1 Young \\
-     --condition2 Old \\
+   kompot de bone_marrow_dm.h5ad -o results.h5ad \
+     --groupby Age \
+     --condition1 Young \
+     --condition2 Old \
      --obsm-key DM_EigenVectors
 
 Why Diffusion Maps?
@@ -267,17 +274,17 @@ Example: Complete Analysis
 
 .. code-block:: bash
 
-   kompot de bone_marrow.h5ad -o results.h5ad \\
-     --groupby Age \\
-     --condition1 Young \\
-     --condition2 Old \\
-     --obsm-key DM_EigenVectors \\
-     --layer logged_counts \\
-     --sample-col Sample \\
-     --n-landmarks 5000 \\
-     --batch-size 100 \\
-     --fdr-threshold 0.05 \\
-     --null-genes 2000 \\
+   kompot de bone_marrow.h5ad -o results.h5ad \
+     --groupby Age \
+     --condition1 Young \
+     --condition2 Old \
+     --obsm-key DM_EigenVectors \
+     --layer logged_counts \
+     --sample-col Sample \
+     --n-landmarks 5000 \
+     --batch-size 100 \
+     --fdr-threshold 0.05 \
+     --null-genes 2000 \
      --store-additional-stats
 
 Differential Abundance Command
@@ -348,15 +355,88 @@ Example: Complete Analysis
 
 .. code-block:: bash
 
-   kompot da bone_marrow.h5ad -o results.h5ad \\
-     --groupby Age \\
-     --condition1 Young \\
-     --condition2 Old \\
-     --obsm-key DM_EigenVectors \\
-     --sample-col Sample \\
-     --n-landmarks 3000 \\
-     --log-fold-change-threshold 1.0 \\
+   kompot da bone_marrow.h5ad -o results.h5ad \
+     --groupby Age \
+     --condition1 Young \
+     --condition2 Old \
+     --obsm-key DM_EigenVectors \
+     --sample-col Sample \
+     --n-landmarks 3000 \
+     --log-fold-change-threshold 1.0 \
      --ptp-threshold 0.05
+
+Smooth Command
+--------------
+
+The ``smooth`` command smooths gene expression for a single condition using GP regression. This is useful for denoising expression data or preparing smoothed expression for downstream analysis.
+
+Basic Usage
+^^^^^^^^^^^
+
+.. code-block:: bash
+
+   kompot smooth INPUT -o OUTPUT [OPTIONS]
+   kompot smooth INPUT -t TABLE_OUTPUT [OPTIONS]
+
+At least one output must be specified: ``-o/--output`` for full AnnData or ``-t/--table-output`` for CSV/TSV summary table (mean smoothed values and standard deviations per gene).
+
+Common Options
+^^^^^^^^^^^^^^
+
+.. code-block:: text
+
+   --groupby COLUMN          # Column in adata.obs with condition labels
+   --condition LABEL         # Which condition to smooth (requires --groupby)
+   --obsm-key KEY            # Cell state representation (default: DM_EigenVectors)
+   --layer LAYER             # Expression data layer (default: None, use X)
+   --result-key KEY          # Storage key (default: kompot_smooth)
+   --n-landmarks N           # Number of landmarks (default: 5000)
+   --sample-col COLUMN       # Sample ID column for sample variance estimation
+   --batch-size N            # Cells per batch (default: 500)
+   --genes GENE [GENE ...]   # Subset of genes to smooth (default: all)
+
+GP Options
+^^^^^^^^^^
+
+.. code-block:: text
+
+   --sigma FLOAT             # Noise level for the GP (default: 1.0)
+   --ls-factor FLOAT         # Length scale factor (default: 10.0)
+   --eps FLOAT               # Numerical stability constant (default: 1e-8)
+   --random-state INT        # Random seed for landmark selection
+
+Boolean Flags
+^^^^^^^^^^^^^
+
+.. code-block:: text
+
+   --use-empirical-variance  # Estimate per-gene heteroscedastic noise from GP residuals
+   --overwrite               # Overwrite existing results without warning
+   --no-progress             # Disable progress bars
+   --use-gpu                 # Use GPU acceleration (requires CUDA-enabled JAX)
+
+Example: Smooth Treatment Condition
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   kompot smooth bone_marrow.h5ad -o smoothed.h5ad \
+     --groupby Age \
+     --condition Old \
+     --obsm-key DM_EigenVectors \
+     --layer logged_counts \
+     --n-landmarks 5000
+
+Example: Gene Summary Table
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   kompot smooth bone_marrow.h5ad \
+     -t gene_summary.csv \
+     --groupby Age \
+     --condition Old \
+     --genes CD34 CD38 THY1
 
 Configuration Files
 -------------------
@@ -477,6 +557,7 @@ Kompot provides ready-to-use templates:
 - ``kompot/cli/templates/dm_config_template.yaml``
 - ``kompot/cli/templates/de_config_template.yaml``
 - ``kompot/cli/templates/da_config_template.yaml``
+- ``kompot/cli/templates/smooth_config_template.yaml``
 
 Pipeline Integration
 --------------------
@@ -526,20 +607,20 @@ Shell Script Example
        echo "Processing ${sample}..."
 
        # Step 1: Compute diffusion maps
-       kompot dm \\
-           data/${sample}.h5ad \\
-           -o temp/${sample}_dm.h5ad \\
-           --pca-key X_pca \\
+       kompot dm \
+           data/${sample}.h5ad \
+           -o temp/${sample}_dm.h5ad \
+           --pca-key X_pca \
            --n-components 10
 
        # Step 2: Differential expression
-       kompot de \\
-           temp/${sample}_dm.h5ad \\
-           -o results/${sample}_de.h5ad \\
-           --groupby condition \\
-           --condition1 control \\
-           --condition2 treatment \\
-           --obsm-key DM_EigenVectors \\
+       kompot de \
+           temp/${sample}_dm.h5ad \
+           -o results/${sample}_de.h5ad \
+           --groupby condition \
+           --condition1 control \
+           --condition2 treatment \
+           --obsm-key DM_EigenVectors \
            --batch-size 100
 
        if [ $? -eq 0 ]; then
@@ -695,6 +776,7 @@ Getting Help
    # Command-specific help
    kompot de --help
    kompot da --help
+   kompot smooth --help
    kompot dm --help
 
    # Check version

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -208,6 +208,7 @@ Boolean Flags
 
 .. code-block:: text
 
+   --dry-run                  # Estimate resources, print plan, exit (no analysis)
    --no-progress             # Disable progress bars
    --store-landmarks           # Store landmarks for reuse
    --store-additional-stats    # Store extra statistics
@@ -247,6 +248,33 @@ Example: Complete Analysis
      --fdr-threshold 0.05 \
      --null-genes 2000 \
      --store-additional-stats
+
+Example: Dry Run (Resource Estimation)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use ``--dry-run`` to check memory and disk requirements before committing
+to a long analysis. JSON is written to stdout (or ``-o`` file); the
+human-readable report goes to stderr.
+
+.. code-block:: bash
+
+   # Print JSON plan to stdout, human report to stderr
+   kompot de bone_marrow.h5ad --dry-run \
+     --groupby Age \
+     --condition1 Young \
+     --condition2 Old
+
+   # Save plan to a file for pipeline consumption
+   kompot de bone_marrow.h5ad --dry-run -o plan.json \
+     --groupby Age \
+     --condition1 Young \
+     --condition2 Old
+
+   # Parse in a pipeline (e.g., check feasibility before submitting a job)
+   kompot de input.h5ad --dry-run --groupby cond --condition1 A --condition2 B \
+     | jq '.feasible'
+
+The exit code is ``0`` if the plan is feasible, ``1`` if not.
 
 Differential Abundance Command
 -------------------------------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -253,26 +253,24 @@ Example: Dry Run (Resource Estimation)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Use ``--dry-run`` to check memory and disk requirements before committing
-to a long analysis. JSON is written to stdout (or ``-o`` file); the
-human-readable report goes to stderr.
+to a long analysis. JSON is written to stdout; the human-readable report
+goes to stderr. Use the same arguments as the real run (``-o`` is ignored).
 
 .. code-block:: bash
 
-   # Print JSON plan to stdout, human report to stderr
+   # Check resources (human report on stderr, JSON on stdout)
    kompot de bone_marrow.h5ad --dry-run \
      --groupby Age \
      --condition1 Young \
      --condition2 Old
 
-   # Save plan to a file for pipeline consumption
-   kompot de bone_marrow.h5ad --dry-run -o plan.json \
-     --groupby Age \
-     --condition1 Young \
-     --condition2 Old
-
-   # Parse in a pipeline (e.g., check feasibility before submitting a job)
+   # Save JSON plan and check feasibility in a pipeline
    kompot de input.h5ad --dry-run --groupby cond --condition1 A --condition2 B \
-     | jq '.feasible'
+     > plan.json && echo "feasible"
+
+   # Parse specific fields with jq
+   kompot de input.h5ad --dry-run --groupby cond --condition1 A --condition2 B \
+     2>/dev/null | jq '.memory.total_human'
 
 The exit code is ``0`` if the plan is feasible, ``1`` if not.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,7 @@
 
    Installation <installation>
    Command-Line Interface <cli>
+   Variance-stratified FDR <variance_stratified_fdr>
 
 .. toctree::
    :hidden:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,7 +26,7 @@
    Getting Started <notebooks/01_getting_started.ipynb>
    Advanced Differential Expression <notebooks/02_differential_expression_detailed.ipynb>
    Sample Variance Analysis <notebooks/03_sample_variance.ipynb>
-   Gene Expression Imputation <notebooks/04_expression_model.ipynb>
+   Gene Expression Smoothing <notebooks/04_expression_model.ipynb>
 
 .. |doi| image:: https://zenodo.org/badge/944121568.svg
    :target: https://zenodo.org/badge/latestdoi/944121568

--- a/docs/source/variance_stratified_fdr.rst
+++ b/docs/source/variance_stratified_fdr.rst
@@ -1,0 +1,133 @@
+Variance-stratified (residual) FDR
+==================================
+
+Kompot's default test statistic is the per-gene Mahalanobis distance
+
+.. math::
+
+   D^2_g = (\mu^{(A)}_g - \mu^{(B)}_g)^\top
+           (\Sigma^{(A)}_g + \Sigma^{(B)}_g)^{-1}
+           (\mu^{(A)}_g - \mu^{(B)}_g)
+
+where :math:`\mu` and :math:`\Sigma` are the GP posterior mean and
+covariance over the manifold.  When
+``GPSettings.use_empirical_variance=False`` (the default — chosen so
+per-cell sampling noise is not conflated with epistemic posterior
+uncertainty), :math:`D^2_g` scales monotonically with per-gene
+expression variance :math:`\sigma^2_g`.  The gene-shuffled empirical
+null inherits that scaling, so the 1-D local FDR is genome-wide
+calibrated but not gene-specific.
+
+This matters most in low-replication designs: with two biological
+replicates per condition, every 2-vs-2 partition — including the real
+one — produces a mean difference roughly proportional to
+:math:`\sigma^2_g`, so any partition ranks high-variance genes at the
+top.  Under a balanced permutation of the Tal1 chimera dataset the raw
+Mahalanobis rank correlation between real and permuted partitions is
+Spearman 0.99 genome-wide and 0.79 in the top 10 %.
+
+When to enable
+--------------
+
+Enable variance-stratified FDR when any of the following apply:
+
+* **n ≈ 2 biological replicates per condition** and you want to
+  interpret the top DE list as *condition-specific* rather than
+  *variability-driven*.
+* You notice that the top-ranked DE genes are suspiciously similar
+  between the real comparison and a balanced permutation of condition
+  labels.
+* You want the FDR calibration to be robust to per-gene mean and
+  variance even when the manifold partition is unbalanced.
+
+Keep the default (``mode="raw"``) when you have well-replicated data
+(≥3 per condition) and want the classical behaviour.
+
+Usage
+-----
+
+.. code-block:: python
+
+   import kompot
+
+   kompot.de(
+       adata, "condition", "WT", "Mutant",
+       fdr=kompot.FDRSettings(
+           mode="variance_stratified",
+           null_trend_features=("log_mean", "log_var"),
+           null_trend_model="poly3",
+       ),
+   )
+
+The raw Mahalanobis, raw local FDR, and ``is_de`` columns are still
+written unchanged.  In addition, the following columns are added to
+``adata.var``:
+
+================================================  ========================================================
+Column                                            Meaning
+================================================  ========================================================
+``..._residual_mahalanobis``                      :math:`\log(1 + D^2_g) - \hat\varphi(m_g, v_g)`
+``..._residual_z``                                residual standardised by :math:`\hat\sigma_{\text{null}}`
+``..._residual_local_fdr``                        local FDR on :math:`Z`
+``..._residual_is_de``                            ``True`` at the configured threshold
+``..._residual_pvalue`` *(additional stats)*      empirical p-value from the residual null
+``..._residual_tail_fdr`` *(additional stats)*    tail FDR on :math:`Z`
+``..._residual_log_mean`` *(additional stats)*    :math:`\log(1+\bar x_g)`
+``..._residual_log_var`` *(additional stats)*     :math:`\log(1+\operatorname{Var}(x_g))`
+================================================  ========================================================
+
+Method
+------
+
+1. Compute :math:`m_g = \log(1 + \bar x_g)` and
+   :math:`v_g = \log(1 + \operatorname{Var}(x_g))` per gene from the
+   expression layer used for DE.
+2. Fit the null-trend surface
+   :math:`\hat\varphi(m, v) = \mathbb{E}[\log(1 + D^2_{\text{null}}) \mid m, v]`
+   by ordinary least squares on the gene-shuffled null draws
+   (``null_trend_model="poly3"`` is a 7-term tensor polynomial).
+3. Estimate the homoscedastic null residual scale
+   :math:`\hat\sigma_{\text{null}}` from the fit.
+4. Define the residualised statistic
+   :math:`R_g = \log(1 + D^2_g) - \hat\varphi(m_g, v_g)` and
+   :math:`Z_g = R_g / \hat\sigma_{\text{null}}`.
+5. Feed :math:`\max(0, Z_g)` to kompot's existing 1-D local FDR (the
+   null of :math:`Z` is centred at zero by construction).  Below-null
+   genes (negative :math:`Z`) are assigned local FDR ≈ 1.
+
+What this does and does not do
+------------------------------
+
+**Does**
+
+* Remove the strictly gene-level monotone dependence on per-gene mean
+  and variance from the statistic before FDR calibration.
+* Rank genes by how unusual their Mahalanobis is *conditional on*
+  their mean and variance.
+
+**Does not**
+
+* Remove manifold / cell-type structure.  Genes that vary strongly
+  between cell types will still have large Mahalanobis under any
+  cell partition that splits cell-type mixtures.
+* Fix the underlying experimental-design limitation of two
+  biological replicates per condition.  With sample fully confounded
+  with condition, no statistic can separate condition-level biology
+  from embryo-to-embryo variability in principle.
+
+Tal1 validation
+---------------
+
+On the Tal1 chimera dataset (2 mutant + 2 WT embryos, 29 453 genes),
+residualisation flips the top-20 genes from an imprinting/X-linked
+variability signature to the known Tal1 hematopoietic phenotype:
+
+* **Raw top-20 hematopoietic genes:** 5 (Hbb-bh1, Hba-x, Hbb-y,
+  Hba-a1, Hba-a2)
+* **Residual top-20 hematopoietic genes:** 11 (also Itga2b, Lyl1,
+  Stab1, Stab2, Tfec, Ackr1)
+* **Raw top-20 imprinted genes:** 12
+* **Residual top-20 imprinted genes:** 0
+
+See the Tal1 validation report in the kompot manuscript supplement for
+the full analysis.

--- a/kompot/__init__.py
+++ b/kompot/__init__.py
@@ -99,6 +99,23 @@ LOGGING_CONFIG = {
 logging.config.dictConfig(LOGGING_CONFIG)
 logger = logging.getLogger("kompot")
 
+
+def configure_logging(stream=None):
+    """Reconfigure the kompot logger to write to a different stream.
+
+    Parameters
+    ----------
+    stream : file-like, optional
+        Output stream for log messages. Defaults to ``sys.stdout``.
+        CLI tools typically pass ``sys.stderr`` so stdout stays clean
+        for machine-parseable output.
+    """
+    if stream is None:
+        stream = sys.stdout
+    for handler in logger.handlers:
+        if hasattr(handler, "stream"):
+            handler.stream = stream
+
 __all__ = [
     # Version
     "__version__",
@@ -122,6 +139,8 @@ __all__ = [
     "StorageSettings",
     "OutputSettings",
     "ModelSettings",
+    # Configuration
+    "configure_logging",
     # Utility functions
     "compute_mahalanobis_distance",
     "find_landmarks",

--- a/kompot/anndata/_de_helpers.py
+++ b/kompot/anndata/_de_helpers.py
@@ -62,6 +62,26 @@ def _check_overwrites(
                     field_names["mahalanobis_tail_fdr_key"],
                 ]
             )
+        # Residual columns share the same overwrite checks.  They may not
+        # be written on every run (only when mode='variance_stratified')
+        # but include them so an existing residual column is detected.
+        all_patterns["var"].extend(
+            [
+                field_names["residual_mahalanobis_key"],
+                field_names["residual_z_key"],
+                field_names["residual_local_fdr_key"],
+                field_names["residual_is_de_key"],
+            ]
+        )
+        if store_additional_stats:
+            all_patterns["var"].extend(
+                [
+                    field_names["residual_pvalue_key"],
+                    field_names["residual_tail_fdr_key"],
+                    field_names["residual_log_mean_key"],
+                    field_names["residual_log_var_key"],
+                ]
+            )
 
     # Update all_patterns with group information if needed
     if groups is not None:
@@ -659,6 +679,104 @@ def _augment_with_external_null_expression(
 # ---------------------------------------------------------------------------
 
 
+def _compute_residual_fdr(
+    real_mahalanobis: np.ndarray,
+    internal_null_mahalanobis: np.ndarray,
+    internal_null_gene_indices: list,
+    n_real: int,
+    expr1: np.ndarray,
+    expr2: np.ndarray,
+    null_trend_model: str,
+    null_trend_features: tuple,
+    fdr_threshold: float,
+) -> Optional[dict]:
+    """Compute variance-stratified residual Mahalanobis + local FDR.
+
+    Returns ``None`` if the inputs cannot support residualisation
+    (no internal null genes, or fewer null draws than design columns).
+    Otherwise returns a dict with the per-real-gene statistics.
+
+    The residual is ``log1p(D^2) - phi_hat(log_mean, log_var)`` where
+    ``phi_hat`` is a smooth surface fit on the permutation null.
+    """
+    from ..residualization import (
+        compute_gene_features,
+        residualize_mahalanobis,
+        residual_local_fdr,
+    )
+
+    if internal_null_gene_indices is None or len(internal_null_gene_indices) == 0:
+        logger.warning(
+            "variance_stratified FDR requires internal null genes "
+            "(null_genes > 0); falling back to raw FDR only."
+        )
+        return None
+
+    if len(internal_null_mahalanobis) < 8:
+        logger.warning(
+            f"variance_stratified FDR needs >7 null draws "
+            f"(got {len(internal_null_mahalanobis)}); skipping residual correction."
+        )
+        return None
+
+    # The real-gene columns in expr1/expr2 are the first n_real
+    # columns; the remaining columns are the shuffled null genes.
+    real_expr1 = expr1[:, :n_real]
+    real_expr2 = expr2[:, :n_real]
+
+    log_mean, log_var = compute_gene_features([real_expr1, real_expr2])
+
+    if len(log_mean) != n_real:
+        logger.warning(
+            f"Expression feature length {len(log_mean)} disagrees with "
+            f"n_real={n_real}; skipping residual correction."
+        )
+        return None
+
+    # Drop features if only log_mean requested
+    if tuple(null_trend_features) == ("log_mean",):
+        # Pass zero log_var but use mean-only model
+        effective_model = "poly3_mean_only"
+    else:
+        effective_model = null_trend_model
+
+    res = residualize_mahalanobis(
+        real_mahalanobis=real_mahalanobis,
+        null_mahalanobis=internal_null_mahalanobis,
+        real_log_mean=log_mean,
+        real_log_var=log_var,
+        null_gene_indices=np.asarray(internal_null_gene_indices, dtype=int),
+        model=effective_model,
+    )
+    pvalues, local_fdr, tail_fdr, is_de = residual_local_fdr(
+        res, fdr_threshold=fdr_threshold
+    )
+
+    logger.info(
+        f"Residual-Mahalanobis FDR: trend R^2 = {res.trend.fit_r2:.3f}, "
+        f"sigma_null = {res.trend.sigma:.3f}, "
+        f"{int(is_de.sum())}/{n_real} genes DE at residual FDR < {fdr_threshold}"
+    )
+
+    return {
+        "residual": res.residual,
+        "z": res.z,
+        "log_mean": res.log_mean,
+        "log_var": res.log_var,
+        "null_residual": res.null_residual,
+        "pvalues": pvalues,
+        "local_fdr": local_fdr,
+        "tail_fdr": tail_fdr,
+        "is_de": is_de,
+        "trend_r2": res.trend.fit_r2,
+        "trend_sigma": res.trend.sigma,
+        "trend_model": res.trend.model,
+        "trend_coef": res.trend.coef,
+        "trend_features": res.trend.features,
+        "n_null": res.trend.n_null,
+    }
+
+
 def _compute_fdr(
     expression_results: dict,
     selected_genes: list,
@@ -670,6 +788,11 @@ def _compute_fdr(
     return_null_data: bool = False,
     return_full_results: bool = False,
     null_seed: Optional[int] = None,
+    residual_mode: bool = False,
+    expr1: Optional[np.ndarray] = None,
+    expr2: Optional[np.ndarray] = None,
+    null_trend_model: str = "poly3",
+    null_trend_features: tuple = ("log_mean", "log_var"),
 ) -> dict:
     """Compute FDR statistics and strip null genes from expression_results.
 
@@ -731,6 +854,25 @@ def _compute_fdr(
         "de_annotation": de_annotation,
         "summary_stats": summary_stats,
     }
+
+    # Optional: variance-stratified residual-Mahalanobis FDR.
+    # Always computed from the *internal* null (residual correction
+    # requires per-draw provenance).  External nulls without
+    # gene-index metadata are not supported here.
+    if residual_mode and expr1 is not None and expr2 is not None:
+        residual = _compute_residual_fdr(
+            real_mahalanobis=real_mahalanobis,
+            internal_null_mahalanobis=internal_null_mahalanobis,
+            internal_null_gene_indices=null_gene_indices,
+            n_real=n_real,
+            expr1=expr1,
+            expr2=expr2,
+            null_trend_model=null_trend_model,
+            null_trend_features=null_trend_features,
+            fdr_threshold=fdr_threshold,
+        )
+        if residual is not None:
+            fdr_results["residual"] = residual
 
     logger.info(
         f"FDR analysis complete: {summary_stats['n_significant']}/"
@@ -970,6 +1112,67 @@ def _store_de_results(
             selected_genes,
             adata,
         )
+
+        # Residual-Mahalanobis columns (variance-stratified FDR)
+        residual = fdr_results.get("residual")
+        if residual is not None:
+            _add_var_column(
+                new_var_columns,
+                field_names["residual_mahalanobis_key"],
+                residual["residual"],
+                selected_genes,
+                adata,
+            )
+            _add_var_column(
+                new_var_columns,
+                field_names["residual_z_key"],
+                residual["z"],
+                selected_genes,
+                adata,
+            )
+            _add_var_column(
+                new_var_columns,
+                field_names["residual_local_fdr_key"],
+                residual["local_fdr"],
+                selected_genes,
+                adata,
+            )
+            _add_var_column_bool(
+                new_var_columns,
+                field_names["residual_is_de_key"],
+                residual["is_de"],
+                selected_genes,
+                adata,
+            )
+            if store_additional_stats:
+                _add_var_column(
+                    new_var_columns,
+                    field_names["residual_pvalue_key"],
+                    residual["pvalues"],
+                    selected_genes,
+                    adata,
+                )
+                _add_var_column(
+                    new_var_columns,
+                    field_names["residual_tail_fdr_key"],
+                    residual["tail_fdr"],
+                    selected_genes,
+                    adata,
+                )
+                _add_var_column(
+                    new_var_columns,
+                    field_names["residual_log_mean_key"],
+                    residual["log_mean"],
+                    selected_genes,
+                    adata,
+                )
+                _add_var_column(
+                    new_var_columns,
+                    field_names["residual_log_var_key"],
+                    residual["log_var"],
+                    selected_genes,
+                    adata,
+                )
 
     # Flush var columns
     if new_var_columns:
@@ -1676,6 +1879,71 @@ def _build_field_mapping(
                 f"local FDR < {fdr_threshold}"
             ),
         }
+
+        # Residual columns, only added when variance_stratified mode was active
+        if fdr_results.get("residual") is not None:
+            fm[field_names["residual_mahalanobis_key"]] = {
+                "location": "var",
+                "type": "residual_mahalanobis",
+                "description": (
+                    "log(1 + D^2) minus the null-trend surface "
+                    "phi_hat(log_mean, log_var); centred at zero for a "
+                    "variance-matched null gene."
+                ),
+            }
+            fm[field_names["residual_z_key"]] = {
+                "location": "var",
+                "type": "residual_z",
+                "description": (
+                    "Residual Mahalanobis standardised by sigma_null "
+                    "(variance-stratified FDR statistic)."
+                ),
+            }
+            fm[field_names["residual_local_fdr_key"]] = {
+                "location": "var",
+                "type": "residual_local_fdr",
+                "description": (
+                    "Local FDR computed on the variance-stratified "
+                    "residual Z-score."
+                ),
+            }
+            fm[field_names["residual_is_de_key"]] = {
+                "location": "var",
+                "type": "residual_is_de",
+                "description": (
+                    f"Boolean indicator of DE at residual local FDR "
+                    f"< {fdr_threshold}."
+                ),
+            }
+            if store_additional_stats:
+                fm[field_names["residual_pvalue_key"]] = {
+                    "location": "var",
+                    "type": "residual_pvalue",
+                    "description": (
+                        "Empirical p-value from the residual null distribution."
+                    ),
+                }
+                fm[field_names["residual_tail_fdr_key"]] = {
+                    "location": "var",
+                    "type": "residual_tail_fdr",
+                    "description": (
+                        "Tail FDR on the variance-stratified residual Z-score."
+                    ),
+                }
+                fm[field_names["residual_log_mean_key"]] = {
+                    "location": "var",
+                    "type": "residual_log_mean",
+                    "description": (
+                        "log1p(mean) per gene, used to fit the null trend."
+                    ),
+                }
+                fm[field_names["residual_log_var_key"]] = {
+                    "location": "var",
+                    "type": "residual_log_var",
+                    "description": (
+                        "log1p(var) per gene, used to fit the null trend."
+                    ),
+                }
 
     return fm
 

--- a/kompot/anndata/differential_expression.py
+++ b/kompot/anndata/differential_expression.py
@@ -146,6 +146,9 @@ def de(
     ext_null_mahalanobis = _fdr.null_mahalanobis
     ext_null_expression = _fdr.null_expression
     combine_with_internal = _fdr.combine_with_internal
+    fdr_mode = _fdr.mode
+    null_trend_features = _fdr.null_trend_features
+    null_trend_model = _fdr.null_trend_model
 
     cell_filter = _filter.cell_filter
     groups = _filter.groups
@@ -488,6 +491,17 @@ def de(
     _has_ext_null = ext_null_mahalanobis is not None
     if use_fdr and (_has_null_genes or _has_ext_null) and compute_mahalanobis:
         logger.debug("Computing FDR statistics from null distribution")
+        residual_mode = fdr_mode == "variance_stratified"
+        # Residual correction requires the internal null (per-draw gene
+        # provenance).  Warn and proceed with raw FDR only if we only
+        # have external nulls.
+        if residual_mode and not _has_null_genes:
+            logger.warning(
+                "FDRSettings.mode='variance_stratified' requires internal "
+                "null genes (null_genes>0).  External-only nulls lack "
+                "per-draw provenance; residual columns will not be written."
+            )
+            residual_mode = False
         fdr_results = _compute_fdr(
             expression_results,
             selected_genes,
@@ -499,6 +513,11 @@ def de(
             return_null_data=return_null_data,
             return_full_results=return_full_results,
             null_seed=null_seed,
+            residual_mode=residual_mode,
+            expr1=expr1 if residual_mode else None,
+            expr2=expr2 if residual_mode else None,
+            null_trend_model=null_trend_model,
+            null_trend_features=null_trend_features,
         )
 
     # ---- 10. Posterior covariance ----
@@ -646,6 +665,9 @@ def de(
                 null_genes=null_genes,
                 null_seed=null_seed,
                 threshold=fdr_threshold,
+                mode=fdr_mode,
+                null_trend_features=null_trend_features,
+                null_trend_model=null_trend_model,
             ),
             filter=FilterSettings(
                 cell_filter=cell_filter,
@@ -757,6 +779,9 @@ def compute_differential_expression(
     null_seed=42,
     fdr_threshold: float = 0.05,
     store_additional_stats: bool = False,
+    fdr_mode: str = "raw",
+    null_trend_features=("log_mean", "log_var"),
+    null_trend_model: str = "poly3",
     **function_kwargs,
 ):
     """Deprecated. Use :func:`kompot.de` instead.
@@ -795,6 +820,9 @@ def compute_differential_expression(
             null_genes=null_genes,
             null_seed=null_seed,
             threshold=fdr_threshold,
+            mode=fdr_mode,
+            null_trend_features=null_trend_features,
+            null_trend_model=null_trend_model,
         ),
         filter=FilterSettings(
             cell_filter=cell_filter,

--- a/kompot/anndata/utils/field_tracking.py
+++ b/kompot/anndata/utils/field_tracking.py
@@ -239,6 +239,16 @@ def generate_output_field_names(
                 "mahalanobis_local_fdr_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_mahalanobis_local_fdr{suffix}",
                 "mahalanobis_tail_fdr_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_mahalanobis_tail_fdr{suffix}",
                 "is_de_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_is_de{suffix}",
+                # Variance-stratified residual outputs (only populated when
+                # FDRSettings.mode='variance_stratified')
+                "residual_mahalanobis_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_residual_mahalanobis{suffix}",
+                "residual_z_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_residual_z{suffix}",
+                "residual_local_fdr_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_residual_local_fdr{suffix}",
+                "residual_tail_fdr_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_residual_tail_fdr{suffix}",
+                "residual_pvalue_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_residual_pvalue{suffix}",
+                "residual_is_de_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_residual_is_de{suffix}",
+                "residual_log_mean_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_residual_log_mean",
+                "residual_log_var_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_residual_log_var",
                 # Add varm field names for group-specific metrics
                 "mean_lfc_varm_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_mean_lfc_groups",
                 "mahalanobis_varm_key": f"{result_key}_{cond1_safe}_to_{cond2_safe}_mahalanobis{suffix}_groups",

--- a/kompot/cli/de.py
+++ b/kompot/cli/de.py
@@ -1,6 +1,7 @@
 """CLI command for differential expression analysis."""
 
 import argparse
+import json
 import sys
 from pathlib import Path
 import logging
@@ -20,6 +21,19 @@ from .compute_config import configure_compute
 
 
 logger = logging.getLogger("kompot.cli")
+
+
+def _json_default(obj):
+    """JSON serializer for numpy types."""
+    import numpy as np
+
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    if isinstance(obj, (np.floating,)):
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
 def add_de_parser(subparsers) -> argparse.ArgumentParser:
@@ -165,6 +179,14 @@ def add_de_parser(subparsers) -> argparse.ArgumentParser:
         help="Estimate per-gene heteroscedastic noise from squared residuals to deflate significance for high-noise genes",
     )
 
+    # Dry run
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Estimate resource requirements and print a plan instead of running the analysis. "
+        "Outputs JSON to stdout for pipeline integration; human-readable report to stderr.",
+    )
+
     # Compute configuration
     parser.add_argument(
         "--use-gpu",
@@ -192,8 +214,8 @@ def run_de(args):
     args
         Parsed arguments from argparse
     """
-    # Validate output arguments
-    if not args.output and not args.table_output:
+    # Validate output arguments (not required for dry-run)
+    if not args.dry_run and not args.output and not args.table_output:
         logger.error("Either --output or --table-output must be specified")
         sys.exit(1)
 
@@ -245,6 +267,7 @@ def run_de(args):
             "command",
             "use_gpu",
             "threads",
+            "dry_run",
         ]
     }
 
@@ -355,23 +378,53 @@ def run_de(args):
         output_kwargs["return_full_results"] = True
     output = OutputSettings(**output_kwargs) if output_kwargs else None
 
+    # Build shared call kwargs
+    call_kwargs = dict(
+        groupby=groupby,
+        condition1=condition1,
+        condition2=condition2,
+        obsm_key=obsm_key,
+        layer=layer,
+        sample_col=sample_col,
+        gp=gp,
+        fdr=fdr,
+        filter=filter_settings,
+        storage=storage,
+        output=output,
+        **params,  # remaining params forwarded as function_kwargs
+    )
+
+    # Dry run: estimate resources, output JSON to stdout, report to stderr
+    if args.dry_run:
+        import io
+
+        try:
+            old_stdout = sys.stdout
+            sys.stdout = sys.stderr  # capture de()'s print(plan.format_report())
+            try:
+                plan = de(adata, dry_run=True, **call_kwargs)
+            finally:
+                sys.stdout = old_stdout
+        except Exception as e:
+            logger.error(f"Dry run failed: {str(e)}")
+            raise
+
+        # Machine-parseable JSON output
+        plan_dict = plan.to_dict()
+        if args.output:
+            output_path = Path(args.output)
+            with open(output_path, "w") as f:
+                json.dump(plan_dict, f, default=_json_default, indent=2)
+                f.write("\n")
+            logger.info(f"Resource plan written to {output_path}")
+        else:
+            json.dump(plan_dict, sys.stdout, default=_json_default, indent=2)
+            print(file=sys.stdout)  # trailing newline
+        sys.exit(0 if plan.is_feasible else 1)
+
     # Run analysis
     try:
-        result_dict = de(
-            adata,
-            groupby=groupby,
-            condition1=condition1,
-            condition2=condition2,
-            obsm_key=obsm_key,
-            layer=layer,
-            sample_col=sample_col,
-            gp=gp,
-            fdr=fdr,
-            filter=filter_settings,
-            storage=storage,
-            output=output,
-            **params,  # remaining params forwarded as function_kwargs
-        )
+        result_dict = de(adata, **call_kwargs)
     except Exception as e:
         logger.error(f"Analysis failed: {str(e)}")
         raise

--- a/kompot/cli/de.py
+++ b/kompot/cli/de.py
@@ -183,8 +183,8 @@ def add_de_parser(subparsers) -> argparse.ArgumentParser:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Estimate resource requirements and print a plan instead of running the analysis. "
-        "Outputs JSON to stdout for pipeline integration; human-readable report to stderr.",
+        help="Estimate resource requirements instead of running the analysis. "
+        "JSON to stdout, human-readable report to stderr. -o/--output is ignored.",
     )
 
     # Compute configuration
@@ -409,17 +409,9 @@ def run_de(args):
             logger.error(f"Dry run failed: {str(e)}")
             raise
 
-        # Machine-parseable JSON output
-        plan_dict = plan.to_dict()
-        if args.output:
-            output_path = Path(args.output)
-            with open(output_path, "w") as f:
-                json.dump(plan_dict, f, default=_json_default, indent=2)
-                f.write("\n")
-            logger.info(f"Resource plan written to {output_path}")
-        else:
-            json.dump(plan_dict, sys.stdout, default=_json_default, indent=2)
-            print(file=sys.stdout)  # trailing newline
+        # Machine-parseable JSON to stdout
+        json.dump(plan.to_dict(), sys.stdout, default=_json_default, indent=2)
+        print(file=sys.stdout)  # trailing newline
         sys.exit(0 if plan.is_feasible else 1)
 
     # Run analysis

--- a/kompot/cli/main.py
+++ b/kompot/cli/main.py
@@ -95,8 +95,12 @@ def main():
     # Parse arguments
     args = parser.parse_args()
 
-    # Setup logging
+    # Setup logging — CLI always logs to stderr so stdout stays clean
+    # for machine-parseable output (e.g., --dry-run JSON, --table-output)
     setup_logging(args.verbose)
+    from .. import configure_logging
+
+    configure_logging(stream=sys.stderr)
 
     # If no command provided, print help
     if not args.command:

--- a/kompot/residualization.py
+++ b/kompot/residualization.py
@@ -1,0 +1,377 @@
+"""Variance-stratified residualization of Mahalanobis distances.
+
+The raw per-gene Mahalanobis statistic ``D^2`` scales with per-gene
+expression variance when ``use_empirical_variance=False`` (kompot's
+default).  Because the gene-shuffled null inherits each gene's ``(mean,
+variance)``, the null distribution of ``log(1 + D^2)`` is itself a
+smooth monotone function of those two summaries.  Fitting that surface
+on the null draws and subtracting it from the observed ``log(1 + D^2)``
+gives a condition-specific test statistic whose null is centred at
+zero with known scale — exactly the quantity kompot's 1-D local FDR
+machinery wants.
+
+See ``docs/variance_stratified_fdr.rst`` for the full derivation and
+the Tal1 chimera validation.
+
+The module is pure numpy / scipy and does not touch AnnData or JAX —
+it can be called post-hoc on any ``(real_mahalanobis, null_mahalanobis,
+null_gene_indices, per_gene_features)`` tuple.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, Sequence, Tuple, Union
+
+import numpy as np
+
+logger = logging.getLogger("kompot")
+
+
+# ---------------------------------------------------------------------------
+# Per-gene (log_mean, log_var) features
+# ---------------------------------------------------------------------------
+
+
+def compute_gene_features(
+    expr_list: Sequence[np.ndarray],
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Compute ``(log_mean, log_var)`` for each gene on the stacked expression.
+
+    Parameters
+    ----------
+    expr_list : sequence of 2-D arrays
+        Each entry has shape ``(n_cells, n_genes)`` with the same
+        ``n_genes``.  Expression matrices for the two (or more)
+        conditions are stacked along the cell axis before computing the
+        per-gene mean and variance.
+
+    Returns
+    -------
+    log_mean, log_var : ndarray of shape ``(n_genes,)``
+        ``log1p`` of per-gene mean and per-gene variance computed over
+        all stacked cells.  Zero-variance genes get ``log_var = 0``.
+    """
+    arrays = [np.asarray(a, dtype=float) for a in expr_list]
+    if not arrays:
+        raise ValueError("expr_list must contain at least one expression matrix.")
+    n_genes = arrays[0].shape[1]
+    for a in arrays:
+        if a.ndim != 2 or a.shape[1] != n_genes:
+            raise ValueError(
+                "All expression matrices must be 2-D with matching gene count."
+            )
+    stacked = np.vstack(arrays)
+
+    mean = stacked.mean(axis=0)
+    var = stacked.var(axis=0)
+
+    # log1p handles zeros gracefully and compresses the dynamic range.
+    return np.log1p(mean), np.log1p(np.maximum(var, 0.0))
+
+
+# ---------------------------------------------------------------------------
+# Null-trend fitting
+# ---------------------------------------------------------------------------
+
+
+def _design_poly3(m: np.ndarray, v: np.ndarray) -> np.ndarray:
+    """Degree-3 tensor design matrix with one cross term.
+
+    Columns: ``[1, m, m^2, m^3, v, v^2, m*v]``.  Seven parameters, no
+    regularisation — adequate for ``n_null >> 7`` which is always the
+    case for kompot's default ``null_genes=2000``.
+    """
+    m = np.asarray(m, dtype=float).ravel()
+    v = np.asarray(v, dtype=float).ravel()
+    return np.column_stack([
+        np.ones_like(m),
+        m,
+        m * m,
+        m * m * m,
+        v,
+        v * v,
+        m * v,
+    ])
+
+
+def _design_mean_only(m: np.ndarray, v: np.ndarray) -> np.ndarray:
+    """Mean-only design: ``[1, m, m^2, m^3]`` — ignores variance feature."""
+    m = np.asarray(m, dtype=float).ravel()
+    return np.column_stack([np.ones_like(m), m, m * m, m * m * m])
+
+
+_DESIGN_BUILDERS = {
+    "poly3": _design_poly3,
+    "poly3_mean_only": _design_mean_only,
+}
+
+
+@dataclass
+class NullTrend:
+    """Fitted null-trend surface ``phi_hat(m, v)``.
+
+    Attributes
+    ----------
+    coef : ndarray
+        Regression coefficients solved via ordinary least squares on
+        ``log1p(null_mahalanobis)``.
+    sigma : float
+        Homoscedastic residual standard deviation of the fit, used to
+        standardise ``R_g`` to ``Z_g``.
+    model : str
+        Name of the design family.
+    features : tuple of str
+        Feature names in the order they appear in the design matrix
+        inputs (``('log_mean', 'log_var')`` or ``('log_mean',)``).
+    n_null : int
+        Number of null draws used to fit the surface.
+    fit_r2 : float
+        Coefficient of determination on the fit.  Reported for
+        diagnostics; a value below ~0.3 usually means the residual
+        correction will do little.
+    """
+
+    coef: np.ndarray
+    sigma: float
+    model: str
+    features: Tuple[str, ...]
+    n_null: int
+    fit_r2: float
+
+    def predict(self, log_mean: np.ndarray, log_var: np.ndarray) -> np.ndarray:
+        """Evaluate ``phi_hat`` at ``(m, v)``."""
+        X = _DESIGN_BUILDERS[self.model](log_mean, log_var)
+        return X @ self.coef
+
+
+def fit_null_trend(
+    null_log_mahalanobis: np.ndarray,
+    null_log_mean: np.ndarray,
+    null_log_var: np.ndarray,
+    model: str = "poly3",
+) -> NullTrend:
+    """Fit the null-trend surface ``phi_hat(m, v)`` on permutation draws.
+
+    The target is ``log1p(null_mahalanobis)`` — taken by the caller so
+    this function can be used with any log1p-transformed statistic.
+
+    Parameters
+    ----------
+    null_log_mahalanobis : ndarray of shape ``(K,)``
+        ``log1p`` of the null Mahalanobis values (one entry per null
+        draw).
+    null_log_mean, null_log_var : ndarray of shape ``(K,)``
+        ``log1p(mean)`` and ``log1p(var)`` of the gene backing each
+        null draw.  For kompot's gene-shuffled null, every draw inherits
+        the features of its source gene; duplicate gene indices are
+        fine.
+    model : str
+        Design family.  ``'poly3'`` (default) fits a 7-term tensor
+        polynomial in ``(m, v)``.  ``'poly3_mean_only'`` drops the
+        variance feature (useful as a diagnostic — we expect a large
+        drop in ``fit_r2``).
+
+    Returns
+    -------
+    NullTrend
+    """
+    y = np.asarray(null_log_mahalanobis, dtype=float).ravel()
+    m = np.asarray(null_log_mean, dtype=float).ravel()
+    v = np.asarray(null_log_var, dtype=float).ravel()
+
+    if y.shape[0] != m.shape[0] or y.shape[0] != v.shape[0]:
+        raise ValueError(
+            "null_log_mahalanobis, null_log_mean and null_log_var must have "
+            f"matching length (got {y.shape[0]}, {m.shape[0]}, {v.shape[0]})."
+        )
+    if model not in _DESIGN_BUILDERS:
+        raise ValueError(
+            f"Unknown null_trend_model '{model}'. "
+            f"Supported: {sorted(_DESIGN_BUILDERS)}."
+        )
+    if y.shape[0] <= _DESIGN_BUILDERS[model](m[:1], v[:1]).shape[1]:
+        raise ValueError(
+            f"Need more null draws than design columns "
+            f"(got {y.shape[0]} for model '{model}')."
+        )
+
+    # Drop non-finite rows — e.g. Mahalanobis = 0 entries from degenerate
+    # null draws propagate as log1p(0)=0 which is fine, but NaN cannot be
+    # inverted by lstsq.
+    finite = np.isfinite(y) & np.isfinite(m) & np.isfinite(v)
+    if not finite.all():
+        dropped = int((~finite).sum())
+        logger.warning(
+            f"Dropping {dropped} non-finite null draws before fitting phi_hat."
+        )
+        y = y[finite]
+        m = m[finite]
+        v = v[finite]
+
+    X = _DESIGN_BUILDERS[model](m, v)
+    coef, _res, _rk, _sv = np.linalg.lstsq(X, y, rcond=None)
+    resid = y - X @ coef
+    sigma = float(np.sqrt(np.mean(resid * resid)))
+    # Protect against the degenerate case where every null draw is identical.
+    if sigma <= 0.0:
+        logger.warning(
+            "Null-trend residual scale is zero — falling back to unit sigma."
+        )
+        sigma = 1.0
+    ss_tot = float(np.sum((y - y.mean()) ** 2))
+    fit_r2 = 1.0 - float(np.sum(resid * resid)) / ss_tot if ss_tot > 0 else 0.0
+
+    features = ("log_mean", "log_var") if model == "poly3" else ("log_mean",)
+
+    return NullTrend(
+        coef=coef,
+        sigma=sigma,
+        model=model,
+        features=features,
+        n_null=int(y.shape[0]),
+        fit_r2=fit_r2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Residualisation
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ResidualisedMahalanobis:
+    """Result of residualising a set of Mahalanobis values.
+
+    Attributes
+    ----------
+    residual : ndarray
+        ``log1p(D^2) - phi_hat(m, v)`` per real gene.  Centred at zero
+        for a variance-matched null gene.
+    z : ndarray
+        ``residual / sigma_null``.  Standard-normal-like under the
+        null.  Negative values are allowed and mean "quieter than a
+        variance-matched null", so the downstream 1-D local FDR uses
+        ``max(0, z)`` as its Mahalanobis surrogate.
+    log_mean, log_var : ndarray
+        Per-gene features.  Kept for diagnostic storage.
+    trend : NullTrend
+        The fitted surface used to residualise.
+    null_residual : ndarray
+        ``log1p(null_D^2) - phi_hat(null_m, null_v)`` — feeds the
+        1-D local FDR as the null distribution of ``z``.
+    """
+
+    residual: np.ndarray
+    z: np.ndarray
+    log_mean: np.ndarray
+    log_var: np.ndarray
+    trend: NullTrend
+    null_residual: np.ndarray
+
+    @property
+    def null_z(self) -> np.ndarray:
+        return self.null_residual / self.trend.sigma
+
+
+def residualize_mahalanobis(
+    real_mahalanobis: np.ndarray,
+    null_mahalanobis: np.ndarray,
+    real_log_mean: np.ndarray,
+    real_log_var: np.ndarray,
+    null_gene_indices: Union[np.ndarray, Sequence[int]],
+    model: str = "poly3",
+) -> ResidualisedMahalanobis:
+    """Fit the null trend and return residualised statistics.
+
+    ``null_gene_indices[k]`` is the column index (into the real-gene
+    feature array) of the gene backing ``null_mahalanobis[k]`` — this is
+    how kompot's internal null stores provenance.  The gene-shuffling
+    scheme preserves each gene's per-cell values, so the backing gene's
+    ``(log_mean, log_var)`` is the correct feature for that null draw.
+    """
+    real_mahalanobis = np.asarray(real_mahalanobis, dtype=float).ravel()
+    null_mahalanobis = np.asarray(null_mahalanobis, dtype=float).ravel()
+    real_log_mean = np.asarray(real_log_mean, dtype=float).ravel()
+    real_log_var = np.asarray(real_log_var, dtype=float).ravel()
+    idx = np.asarray(null_gene_indices, dtype=int).ravel()
+
+    if real_log_mean.shape[0] != real_log_var.shape[0]:
+        raise ValueError(
+            "real_log_mean and real_log_var must have the same length."
+        )
+    n_real = real_mahalanobis.shape[0]
+    if n_real != real_log_mean.shape[0]:
+        raise ValueError(
+            f"real_mahalanobis length {n_real} does not match "
+            f"per-gene feature length {real_log_mean.shape[0]}."
+        )
+    if idx.shape[0] != null_mahalanobis.shape[0]:
+        raise ValueError(
+            f"null_gene_indices length {idx.shape[0]} must match "
+            f"null_mahalanobis length {null_mahalanobis.shape[0]}."
+        )
+    bad = (idx < 0) | (idx >= real_log_mean.shape[0])
+    if bad.any():
+        raise ValueError(
+            f"null_gene_indices contains {int(bad.sum())} out-of-range entries."
+        )
+
+    null_m = real_log_mean[idx]
+    null_v = real_log_var[idx]
+    null_log = np.log1p(null_mahalanobis)
+    trend = fit_null_trend(null_log, null_m, null_v, model=model)
+
+    null_phi = trend.predict(null_m, null_v)
+    null_residual = null_log - null_phi
+
+    real_phi = trend.predict(real_log_mean, real_log_var)
+    residual = np.log1p(real_mahalanobis) - real_phi
+    z = residual / trend.sigma
+
+    return ResidualisedMahalanobis(
+        residual=residual,
+        z=z,
+        log_mean=real_log_mean,
+        log_var=real_log_var,
+        trend=trend,
+        null_residual=null_residual,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FDR on residuals
+# ---------------------------------------------------------------------------
+
+
+def residual_local_fdr(
+    residualised: ResidualisedMahalanobis,
+    fdr_threshold: float = 0.05,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Apply kompot's 1-D local FDR to the standardised residuals.
+
+    The residual statistic can be negative (a gene that is *quieter*
+    than the variance-matched null).  Local FDR on a strictly
+    non-negative quantity is what kompot implements, so we feed
+    ``max(0, Z)`` — negative ``Z`` maps to zero Mahalanobis-surrogate
+    and therefore local FDR near 1.  This is the intended behaviour:
+    below-null genes are not DE.
+
+    Returns
+    -------
+    pvalues, local_fdr, tail_fdr, is_de
+        Same shape as ``residualised.residual``.  ``is_de`` is
+        ``local_fdr < fdr_threshold``.
+    """
+    from .anndata.fdr_utils import compute_fdr_statistics
+
+    real_z = np.clip(residualised.z, 0.0, None)
+    null_z = np.clip(residualised.null_z, 0.0, None)
+
+    pvalues, local_fdr, tail_fdr, is_de = compute_fdr_statistics(
+        real_mahalanobis=real_z,
+        null_mahalanobis=null_z,
+        fdr_threshold=fdr_threshold,
+    )
+    return pvalues, local_fdr, tail_fdr, is_de

--- a/kompot/resource_estimation.py
+++ b/kompot/resource_estimation.py
@@ -340,6 +340,87 @@ class ResourcePlan:
 
         return "\n".join(lines)
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the resource plan to a JSON-compatible dictionary.
+
+        Designed for machine-parseable output in CLI pipelines.
+
+        Returns
+        -------
+        dict
+            Dictionary with keys: feasible, status, memory, disk,
+            output_fields, info, warnings, errors.
+        """
+        memory_reqs = [r for r in self.requirements if r.resource_type == "memory"]
+        disk_reqs = [r for r in self.requirements if r.resource_type == "disk"]
+
+        result: Dict[str, Any] = {
+            "feasible": self.is_feasible,
+            "status": (
+                "infeasible"
+                if self.errors
+                else "warnings" if self.warnings else "ok"
+            ),
+        }
+
+        # Memory section
+        mem: Dict[str, Any] = {
+            "total_bytes": self.total_memory_required,
+            "total_human": human_readable_size(self.total_memory_required),
+        }
+        if self.availability:
+            mem["available_bytes"] = self.availability.memory_available
+            mem["available_human"] = self.availability.memory_available_human
+            mem["ratio"] = round(self.memory_ratio, 4)
+        mem["allocations"] = [
+            {
+                "name": r.name,
+                "bytes": r.size_bytes,
+                "human": r.size_human,
+                **({"shape": list(r.shape)} if r.shape else {}),
+                **({"field": r.field_name} if r.field_name else {}),
+                **({"overwrite": True} if r.overwrite else {}),
+            }
+            for r in memory_reqs
+        ]
+        result["memory"] = mem
+
+        # Disk section
+        dsk: Dict[str, Any] = {
+            "total_bytes": self.total_disk_required,
+            "total_human": human_readable_size(self.total_disk_required),
+        }
+        if self.availability:
+            dsk["available_bytes"] = self.availability.disk_available
+            dsk["available_human"] = self.availability.disk_available_human
+            dsk["path"] = self.availability.disk_path
+            dsk["ratio"] = round(self.disk_ratio, 4)
+        dsk["allocations"] = [
+            {
+                "name": r.name,
+                "bytes": r.size_bytes,
+                "human": r.size_human,
+                **({"shape": list(r.shape)} if r.shape else {}),
+                **({"overwrite": True} if r.overwrite else {}),
+            }
+            for r in disk_reqs
+        ]
+        result["disk"] = dsk
+
+        # Output fields
+        if self.output_fields:
+            result["output_fields"] = self.output_fields
+
+        # Messages
+        if self.info:
+            result["info"] = self.info
+        if self.warnings:
+            result["warnings"] = self.warnings
+        if self.errors:
+            result["errors"] = self.errors
+
+        return result
+
 
 def get_system_resources(disk_path: Optional[str] = None) -> ResourceAvailability:
     """

--- a/kompot/settings.py
+++ b/kompot/settings.py
@@ -137,6 +137,32 @@ class FDRSettings:
         If ``True``, concatenate external null distances with
         internally generated null distances.  If ``False`` (default),
         the external null replaces the internal one entirely.
+    mode : str
+        FDR calibration mode.
+
+        * ``"raw"`` (default) — kompot's original local FDR on the
+          Mahalanobis distance ``D^2``.
+        * ``"variance_stratified"`` — in addition to the raw statistic,
+          residualise ``log(1 + D^2)`` against a smooth function of
+          per-gene ``log_mean`` and ``log_var`` fit on the permutation
+          null, standardise by the null residual scale, and apply the
+          1-D local FDR to the resulting ``Z`` score.  Results are
+          stored under ``*_residual_*`` column names alongside the
+          untouched raw outputs.  Use this mode when the number of
+          biological replicates per condition is small (~2) and raw
+          ``D^2`` is dominated by per-gene variance rather than
+          condition.  See ``docs/variance_stratified_fdr.rst``.
+    null_trend_features : tuple of str
+        Features used to fit the null trend surface.  Only
+        ``('log_mean', 'log_var')`` and ``('log_mean',)`` are supported
+        today; pass the shorter tuple to drop the variance feature as
+        a diagnostic.
+    null_trend_model : str
+        Smooth family used to fit ``phi_hat(m, v)`` on the null.
+        ``'poly3'`` (default) — 7-term tensor polynomial.
+        ``'poly3_mean_only'`` — degree-3 polynomial in mean only;
+        selected automatically when ``null_trend_features`` has a
+        single entry.
     """
 
     null_genes: Union[int, List[int], str, None] = "auto"
@@ -147,6 +173,16 @@ class FDRSettings:
     null_mahalanobis: Optional[np.ndarray] = None
     null_expression: Optional[Tuple[np.ndarray, np.ndarray]] = None
     combine_with_internal: bool = False
+
+    # Variance-stratified residual FDR (opt-in, non-breaking).  When
+    # ``mode='variance_stratified'`` kompot additionally residualises
+    # ``log(1 + D^2)`` against a smooth surface in
+    # ``(log_mean, log_var)`` fit on the permutation null, then applies
+    # the standard 1-D local FDR to the standardised residual.
+    # The raw mahalanobis / local-fdr columns are untouched.
+    mode: str = "raw"
+    null_trend_features: Tuple[str, ...] = ("log_mean", "log_var")
+    null_trend_model: str = "poly3"
 
     def __post_init__(self):
         # null_genes: "auto", int >= 0, list of ints, or None
@@ -182,6 +218,37 @@ class FDRSettings:
             raise ValueError(
                 "'null_mahalanobis' and 'null_expression' are mutually "
                 "exclusive. Provide one or the other, not both."
+            )
+
+        # Validate variance-stratified knobs
+        valid_modes = {"raw", "variance_stratified"}
+        if self.mode not in valid_modes:
+            raise ValueError(
+                f"'mode' must be one of {sorted(valid_modes)} (got '{self.mode}')."
+            )
+
+        if isinstance(self.null_trend_features, list):
+            self.null_trend_features = tuple(self.null_trend_features)
+        if not isinstance(self.null_trend_features, tuple):
+            raise TypeError(
+                f"'null_trend_features' must be a tuple or list of strings "
+                f"(got {type(self.null_trend_features).__name__})."
+            )
+        allowed_features = {
+            ("log_mean", "log_var"),
+            ("log_mean",),
+        }
+        if self.null_trend_features not in allowed_features:
+            raise ValueError(
+                f"'null_trend_features' must be one of {sorted(allowed_features)} "
+                f"(got {self.null_trend_features})."
+            )
+
+        valid_models = {"poly3", "poly3_mean_only"}
+        if self.null_trend_model not in valid_models:
+            raise ValueError(
+                f"'null_trend_model' must be one of {sorted(valid_models)} "
+                f"(got '{self.null_trend_model}')."
             )
 
 

--- a/tests/test_cli_compute_config.py
+++ b/tests/test_cli_compute_config.py
@@ -250,6 +250,7 @@ class TestCLIDEUnitTests:
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Should exit with error
@@ -290,6 +291,7 @@ class TestCLIDEUnitTests:
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Should exit with error or raise FileNotFoundError
@@ -332,6 +334,7 @@ class TestCLIDEUnitTests:
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Should exit with error
@@ -385,6 +388,7 @@ n_landmarks: 15
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Mock compute_differential_expression to avoid actual computation
@@ -437,6 +441,7 @@ n_landmarks: 15
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Mock compute_differential_expression to return mock results
@@ -500,6 +505,7 @@ n_landmarks: 15
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Mock compute_differential_expression
@@ -555,6 +561,7 @@ n_landmarks: 15
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Mock compute_differential_expression
@@ -608,6 +615,7 @@ n_landmarks: 15
             store_landmarks=False,
             store_additional_stats=False,
             overwrite=False,
+            dry_run=False,
         )
 
         # Mock compute_differential_expression

--- a/tests/test_cli_compute_config.py
+++ b/tests/test_cli_compute_config.py
@@ -5,6 +5,8 @@ These tests directly call CLI functions to ensure coverage is captured
 (subprocess tests don't contribute to coverage).
 """
 
+import sys
+
 import pytest
 import os
 import numpy as np

--- a/tests/test_cli_compute_config.py
+++ b/tests/test_cli_compute_config.py
@@ -634,6 +634,213 @@ n_landmarks: 15
         assert exc_info.value.code == 1
 
 
+class TestCLIDryRun:
+    """Tests for the --dry-run flag on the DE CLI."""
+
+    def test_dry_run_outputs_json(self, sample_adata_for_cli, tmp_path, monkeypatch, capsys):
+        """Test that --dry-run outputs JSON to stdout and exits."""
+        from kompot.cli.de import run_de
+        import argparse
+
+        input_file = tmp_path / "input.h5ad"
+        sample_adata_for_cli.write_h5ad(input_file)
+
+        args = argparse.Namespace(
+            input=str(input_file),
+            output=str(tmp_path / "output.h5ad"),
+            table_output=None,
+            config=None,
+            groupby="condition",
+            condition1="A",
+            condition2="B",
+            obsm_key="DM_EigenVectors",
+            sample_col="sample",
+            n_landmarks=10,
+            func=None,
+            verbose=False,
+            command="de",
+            use_gpu=False,
+            threads=None,
+            layer=None,
+            result_key=None,
+            batch_size=None,
+            fdr_threshold=None,
+            null_genes=None,
+            null_seed=None,
+            no_progress=True,
+            store_landmarks=False,
+            store_additional_stats=False,
+            overwrite=False,
+            dry_run=True,
+        )
+
+        # Mock de() to return a plan object with the expected interface
+        class MockPlan:
+            is_feasible = True
+            def to_dict(self):
+                return {"feasible": True, "memory": {"total_bytes": 1024}}
+            def format_report(self):
+                return "Mock report"
+
+        def mock_de(adata, dry_run=False, **kwargs):
+            if dry_run:
+                return MockPlan()
+            return None
+
+        monkeypatch.setattr("kompot.cli.de.de", mock_de)
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_de(args)
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        import json
+        result = json.loads(captured.out)
+        assert result["feasible"] is True
+
+    def test_dry_run_infeasible_exits_1(self, sample_adata_for_cli, tmp_path, monkeypatch):
+        """Test that --dry-run exits with code 1 when plan is infeasible."""
+        from kompot.cli.de import run_de
+        import argparse
+
+        input_file = tmp_path / "input.h5ad"
+        sample_adata_for_cli.write_h5ad(input_file)
+
+        args = argparse.Namespace(
+            input=str(input_file),
+            output=str(tmp_path / "output.h5ad"),
+            table_output=None,
+            config=None,
+            groupby="condition",
+            condition1="A",
+            condition2="B",
+            obsm_key="DM_EigenVectors",
+            sample_col="sample",
+            n_landmarks=10,
+            func=None,
+            verbose=False,
+            command="de",
+            use_gpu=False,
+            threads=None,
+            layer=None,
+            result_key=None,
+            batch_size=None,
+            fdr_threshold=None,
+            null_genes=None,
+            null_seed=None,
+            no_progress=True,
+            store_landmarks=False,
+            store_additional_stats=False,
+            overwrite=False,
+            dry_run=True,
+        )
+
+        class MockPlan:
+            is_feasible = False
+            def to_dict(self):
+                return {"feasible": False}
+            def format_report(self):
+                return "Not feasible"
+
+        def mock_de(adata, dry_run=False, **kwargs):
+            if dry_run:
+                return MockPlan()
+            return None
+
+        monkeypatch.setattr("kompot.cli.de.de", mock_de)
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_de(args)
+
+        assert exc_info.value.code == 1
+
+    def test_dry_run_skips_output_validation(self, sample_adata_for_cli, tmp_path, monkeypatch):
+        """Test that --dry-run does not require --output."""
+        from kompot.cli.de import run_de
+        import argparse
+
+        input_file = tmp_path / "input.h5ad"
+        sample_adata_for_cli.write_h5ad(input_file)
+
+        args = argparse.Namespace(
+            input=str(input_file),
+            output=None,
+            table_output=None,
+            config=None,
+            groupby="condition",
+            condition1="A",
+            condition2="B",
+            obsm_key="DM_EigenVectors",
+            sample_col="sample",
+            n_landmarks=10,
+            func=None,
+            verbose=False,
+            command="de",
+            use_gpu=False,
+            threads=None,
+            layer=None,
+            result_key=None,
+            batch_size=None,
+            fdr_threshold=None,
+            null_genes=None,
+            null_seed=None,
+            no_progress=True,
+            store_landmarks=False,
+            store_additional_stats=False,
+            overwrite=False,
+            dry_run=True,
+        )
+
+        class MockPlan:
+            is_feasible = True
+            def to_dict(self):
+                return {"feasible": True}
+            def format_report(self):
+                return "OK"
+
+        def mock_de(adata, dry_run=False, **kwargs):
+            if dry_run:
+                return MockPlan()
+            return None
+
+        monkeypatch.setattr("kompot.cli.de.de", mock_de)
+
+        # Should NOT exit with "output required" error — dry-run skips that check
+        with pytest.raises(SystemExit) as exc_info:
+            run_de(args)
+
+        assert exc_info.value.code == 0
+
+
+class TestConfigureLogging:
+    """Tests for kompot.configure_logging()."""
+
+    def test_configure_logging_to_stderr(self):
+        """Test that configure_logging redirects the logger."""
+        import io
+        import kompot
+
+        buf = io.StringIO()
+        kompot.configure_logging(buf)
+
+        kompot.logger.info("test message")
+        output = buf.getvalue()
+        assert "test message" in output
+
+        # Restore default
+        kompot.configure_logging(sys.stdout)
+
+    def test_configure_logging_default_stdout(self):
+        """Test that configure_logging defaults to stdout."""
+        import kompot
+
+        kompot.configure_logging()
+        for handler in kompot.logger.handlers:
+            if hasattr(handler, "stream"):
+                assert handler.stream is sys.stdout
+                break
+
+
 class TestCLIDAUnitTests:
     """Unit tests for DA CLI functions."""
 

--- a/tests/test_params_utils.py
+++ b/tests/test_params_utils.py
@@ -36,6 +36,9 @@ class TestSettingsToDict:
             "null_mahalanobis": None,
             "null_expression": None,
             "combine_with_internal": False,
+            "mode": "raw",
+            "null_trend_features": ("log_mean", "log_var"),
+            "null_trend_model": "poly3",
         }
 
     def test_numpy_array_replaced(self):

--- a/tests/test_residualization.py
+++ b/tests/test_residualization.py
@@ -1,0 +1,328 @@
+"""Tests for variance-stratified residual Mahalanobis FDR."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import anndata as ad
+
+import kompot
+from kompot import FDRSettings, GPSettings, OutputSettings
+from kompot.residualization import (
+    NullTrend,
+    compute_gene_features,
+    fit_null_trend,
+    residualize_mahalanobis,
+    residual_local_fdr,
+)
+
+
+# ---------------------------------------------------------------------------
+# Feature extraction
+# ---------------------------------------------------------------------------
+
+
+class TestComputeGeneFeatures:
+    def test_shapes_and_nonneg(self):
+        rng = np.random.default_rng(0)
+        X1 = rng.exponential(1.0, (30, 10))
+        X2 = rng.exponential(1.0, (20, 10))
+        m, v = compute_gene_features([X1, X2])
+        assert m.shape == (10,)
+        assert v.shape == (10,)
+        assert np.all(m >= 0)
+        assert np.all(v >= 0)
+
+    def test_zero_variance_gene_is_finite(self):
+        # A gene with zero variance (all cells equal) must not blow up
+        X1 = np.zeros((5, 3))
+        X2 = np.zeros((5, 3))
+        X1[:, 0] = 2.0
+        X2[:, 0] = 2.0
+        m, v = compute_gene_features([X1, X2])
+        assert np.isfinite(m).all()
+        assert np.isfinite(v).all()
+        assert v[0] == 0.0  # zero variance -> log1p(0) = 0
+        assert v[1] == 0.0
+        assert v[2] == 0.0
+
+    def test_stacking_matches_pooled(self):
+        rng = np.random.default_rng(1)
+        X1 = rng.normal(0, 1, (40, 5))
+        X2 = rng.normal(0, 1, (60, 5))
+        m, v = compute_gene_features([X1, X2])
+        stacked = np.vstack([X1, X2])
+        np.testing.assert_allclose(m, np.log1p(stacked.mean(axis=0)))
+        np.testing.assert_allclose(v, np.log1p(stacked.var(axis=0)))
+
+    def test_mismatched_gene_count_raises(self):
+        with pytest.raises(ValueError, match="matching gene count"):
+            compute_gene_features([np.zeros((5, 3)), np.zeros((5, 4))])
+
+
+# ---------------------------------------------------------------------------
+# Null trend fitting
+# ---------------------------------------------------------------------------
+
+
+class TestFitNullTrend:
+    def test_known_trend_is_recovered(self):
+        """Reconstruct a synthetic polynomial trend with high R^2."""
+        rng = np.random.default_rng(42)
+        n = 2000
+        m = rng.uniform(0, 3, n)
+        v = rng.uniform(0, 3, n)
+        # Ground-truth surface: 2*m + 1.5*v + 0.3*m*v - 0.1*m**2
+        phi_true = 2.0 * m + 1.5 * v + 0.3 * m * v - 0.1 * m * m
+        # log1p of the Mahalanobis-like signal is phi + noise
+        y = phi_true + rng.normal(0, 0.1, n)
+
+        trend = fit_null_trend(y, m, v, model="poly3")
+
+        # High R^2 because our model covers the ground-truth terms
+        assert trend.fit_r2 > 0.95
+        # The residual scale should be near the noise sd we injected
+        assert abs(trend.sigma - 0.1) < 0.02
+        # Predicting at the fit points must be near the ground truth
+        phi_hat = trend.predict(m, v)
+        np.testing.assert_allclose(phi_hat, phi_true, atol=0.05)
+
+    def test_short_input_raises(self):
+        with pytest.raises(ValueError, match="more null draws"):
+            fit_null_trend(
+                np.arange(3.0),
+                np.arange(3.0),
+                np.arange(3.0),
+                model="poly3",
+            )
+
+    def test_mean_only_model_ignores_variance(self):
+        """Residuals should not change when variance is shuffled."""
+        rng = np.random.default_rng(0)
+        n = 1000
+        m = rng.uniform(0, 3, n)
+        v = rng.uniform(0, 3, n)
+        y = 1.5 * m + 0.2 * m * m + rng.normal(0, 0.15, n)
+
+        trend_full = fit_null_trend(y, m, v, model="poly3_mean_only")
+        trend_shuffled = fit_null_trend(
+            y, m, rng.permutation(v), model="poly3_mean_only"
+        )
+
+        # Mean-only model must give identical coefficients regardless of v
+        np.testing.assert_allclose(trend_full.coef, trend_shuffled.coef)
+        assert trend_full.features == ("log_mean",)
+
+    def test_unknown_model_raises(self):
+        with pytest.raises(ValueError, match="Unknown null_trend_model"):
+            fit_null_trend(np.zeros(10), np.zeros(10), np.zeros(10), model="xyz")
+
+    def test_mismatched_lengths_raise(self):
+        with pytest.raises(ValueError, match="matching length"):
+            fit_null_trend(np.zeros(10), np.zeros(9), np.zeros(10))
+
+
+# ---------------------------------------------------------------------------
+# Residualization end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestResidualizeMahalanobis:
+    def test_removes_known_trend(self):
+        """
+        If we build a Mahalanobis-like statistic that is exactly a smooth
+        function of (m, v) plus noise, the residual should be dominated by
+        that noise, not by m or v.
+        """
+        rng = np.random.default_rng(7)
+        n_genes = 500
+        m = rng.uniform(0.1, 3.0, n_genes)
+        v = rng.uniform(0.1, 3.0, n_genes)
+
+        # True null surface
+        phi_true = 2.0 * m + 1.5 * v + 0.3 * m * v
+        # Null draws: sample null_idx uniformly over genes
+        n_null = 3000
+        null_idx = rng.integers(0, n_genes, n_null)
+        noise = rng.normal(0, 0.2, n_null)
+        null_log = phi_true[null_idx] + noise
+        null_mahal = np.expm1(null_log)
+
+        # Real: 490 variance-matched null genes, 10 true DE genes
+        real_log = phi_true + rng.normal(0, 0.2, n_genes)
+        de_idx = np.array([13, 71, 142, 205, 298, 337, 400, 423, 470, 491])
+        real_log[de_idx] += 3.0
+        real_mahal = np.expm1(real_log)
+
+        res = residualize_mahalanobis(
+            real_mahalanobis=real_mahal,
+            null_mahalanobis=null_mahal,
+            real_log_mean=m,
+            real_log_var=v,
+            null_gene_indices=null_idx,
+            model="poly3",
+        )
+
+        # Residual should correlate strongly with the injected spike, not with m/v
+        spike = np.zeros(n_genes)
+        spike[de_idx] = 1.0
+        corr_spike = np.corrcoef(res.residual, spike)[0, 1]
+        corr_mean = np.corrcoef(res.residual, m)[0, 1]
+        corr_var = np.corrcoef(res.residual, v)[0, 1]
+        assert corr_spike > 0.5
+        assert abs(corr_mean) < 0.2
+        assert abs(corr_var) < 0.2
+
+        # Top-10 by residual must include all 10 DE genes
+        top10 = set(np.argsort(res.residual)[::-1][:10].tolist())
+        assert set(de_idx.tolist()).issubset(top10)
+
+        # Top-10 by RAW should be dominated by high-(m,v) genes, not DE
+        top10_raw = set(np.argsort(real_mahal)[::-1][:10].tolist())
+        assert len(top10_raw.intersection(de_idx)) < 10
+
+    def test_mismatched_lengths_raise(self):
+        with pytest.raises(ValueError, match="per-gene feature length"):
+            residualize_mahalanobis(
+                real_mahalanobis=np.ones(5),
+                null_mahalanobis=np.ones(10),
+                real_log_mean=np.ones(6),
+                real_log_var=np.ones(6),
+                null_gene_indices=np.zeros(10, int),
+            )
+
+    def test_bad_null_index_raises(self):
+        with pytest.raises(ValueError, match="out-of-range"):
+            residualize_mahalanobis(
+                real_mahalanobis=np.ones(3),
+                null_mahalanobis=np.ones(100),
+                real_log_mean=np.ones(3),
+                real_log_var=np.ones(3),
+                null_gene_indices=np.array([0, 1, 2, 99] + [0] * 96),
+            )
+
+    def test_residual_local_fdr_negative_z_maps_to_high_lfdr(self):
+        """A below-null-mean gene gets local_fdr close to 1."""
+        rng = np.random.default_rng(99)
+        n_genes = 200
+        m = rng.uniform(0, 2, n_genes)
+        v = rng.uniform(0, 2, n_genes)
+        null_idx = rng.integers(0, n_genes, 1500)
+        null_log = 2.0 * m[null_idx] + v[null_idx] + rng.normal(0, 0.2, 1500)
+        null_mahal = np.expm1(null_log)
+        real_log = 2.0 * m + v + rng.normal(0, 0.2, n_genes)
+        # Force one gene well below the null mean
+        real_log[5] = -1.0
+        real_mahal = np.expm1(np.clip(real_log, 0.0, None))
+
+        res = residualize_mahalanobis(
+            real_mahal, null_mahal, m, v, null_idx, model="poly3"
+        )
+        _pvalues, lfdr, _tail_fdr, is_de = residual_local_fdr(res, 0.05)
+        assert lfdr[5] >= 0.5
+        assert not is_de[5]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration through kompot.de
+# ---------------------------------------------------------------------------
+
+
+def _make_variance_stratified_adata(seed: int = 0) -> "ad.AnnData":
+    """Two conditions, 80 genes: 60 low-variance, 20 high-variance
+    "background" genes.  True DE is injected on 10 low-variance genes so
+    the raw Mahalanobis is dominated by the high-variance background and
+    residualisation is needed to see the signal.
+    """
+    rng = np.random.default_rng(seed)
+    n_cells = 200
+    n_genes = 80
+    de_idx = np.arange(20, 30)  # low-variance genes
+    var_scale = np.concatenate([np.full(20, 3.0), np.full(60, 0.5)])
+
+    X_A = rng.normal(0.0, var_scale, (n_cells // 2, n_genes))
+    X_B = rng.normal(0.0, var_scale, (n_cells // 2, n_genes))
+    X_B[:, de_idx] += 2.5  # injected DE on low-variance genes
+    X = np.vstack([X_A, X_B])
+
+    states = rng.normal(0.0, 1.0, (n_cells, 5))
+    adata = ad.AnnData(X)
+    adata.obsm["DM_EigenVectors"] = states
+    adata.obs["condition"] = pd.Categorical(
+        ["A"] * (n_cells // 2) + ["B"] * (n_cells // 2)
+    )
+    adata.var_names = [f"g{i}" for i in range(n_genes)]
+    return adata, de_idx
+
+
+class TestDeIntegration:
+    def test_residual_mode_writes_residual_columns(self):
+        adata, de_idx = _make_variance_stratified_adata()
+        kompot.de(
+            adata,
+            "condition",
+            "A",
+            "B",
+            gp=GPSettings(n_landmarks=30, random_state=0),
+            fdr=FDRSettings(
+                null_genes=500, null_seed=0, mode="variance_stratified"
+            ),
+            output=OutputSettings(progress=False, allow_single_condition_variance=True),
+        )
+        cols = adata.var.columns
+        # raw columns still there
+        assert "kompot_de_A_to_B_mahalanobis" in cols
+        assert "kompot_de_A_to_B_mahalanobis_local_fdr" in cols
+        assert "kompot_de_A_to_B_is_de" in cols
+        # residual columns added
+        assert "kompot_de_A_to_B_residual_mahalanobis" in cols
+        assert "kompot_de_A_to_B_residual_z" in cols
+        assert "kompot_de_A_to_B_residual_local_fdr" in cols
+        assert "kompot_de_A_to_B_residual_is_de" in cols
+
+        # Residual mode should recover more of the injected DE genes than raw.
+        is_de_raw = adata.var["kompot_de_A_to_B_is_de"].values.astype(bool)
+        is_de_res = adata.var["kompot_de_A_to_B_residual_is_de"].values.astype(bool)
+        de_recall_raw = is_de_raw[de_idx].sum()
+        de_recall_res = is_de_res[de_idx].sum()
+        assert de_recall_res >= de_recall_raw
+        # Require at least 7/10 DE genes called by the residual mode
+        assert de_recall_res >= 7
+
+    def test_raw_mode_is_default_and_writes_no_residual(self):
+        adata, _ = _make_variance_stratified_adata()
+        kompot.de(
+            adata,
+            "condition",
+            "A",
+            "B",
+            gp=GPSettings(n_landmarks=30, random_state=0),
+            fdr=FDRSettings(null_genes=500, null_seed=0),  # default mode="raw"
+            output=OutputSettings(progress=False, allow_single_condition_variance=True),
+        )
+        # residual columns must NOT be present when mode='raw'
+        for col in adata.var.columns:
+            assert "residual" not in col, f"unexpected residual column: {col}"
+
+
+# ---------------------------------------------------------------------------
+# Settings validation
+# ---------------------------------------------------------------------------
+
+
+class TestFDRSettingsModes:
+    def test_default_mode_is_raw(self):
+        s = FDRSettings()
+        assert s.mode == "raw"
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="'mode' must be one of"):
+            FDRSettings(mode="bogus")
+
+    def test_invalid_trend_features_raises(self):
+        with pytest.raises(ValueError, match="null_trend_features"):
+            FDRSettings(null_trend_features=("foo",))
+
+    def test_invalid_trend_model_raises(self):
+        with pytest.raises(ValueError, match="null_trend_model"):
+            FDRSettings(null_trend_model="spline")


### PR DESCRIPTION
## Summary

Opt-in FDR calibration mode `FDRSettings(mode="variance_stratified")` that residualises `log(1 + D²)` against a smooth surface in `(log_mean, log_var)` fit on the permutation null, then applies kompot's existing 1-D local FDR to the standardised residual `Z`. Intended for low-replication designs (≈2 biological replicates per condition), where the raw Mahalanobis is dominated by per-gene variance rather than condition-specific signal.

- Default behaviour is **unchanged** (`mode="raw"`).
- Raw `*_mahalanobis`, `*_mahalanobis_local_fdr`, and `*_is_de` columns are preserved.
- New columns added alongside:
  `*_residual_mahalanobis`, `*_residual_z`, `*_residual_local_fdr`, `*_residual_is_de`
  (plus `_pvalue` / `_tail_fdr` / `_log_mean` / `_log_var` under `store_additional_stats=True`).
- Public helpers in `kompot.residualization` for post-hoc use on any existing kompot output.

## Background

When `GPSettings.use_empirical_variance=False` (kompot's default — chosen so per-cell sampling noise is not conflated with epistemic posterior uncertainty), `D²_g` scales monotonically with per-gene expression variance `σ²_g`. The gene-shuffled null inherits that scaling, so the 1-D local FDR is genome-wide calibrated but not gene-specific. With ~2 replicates per condition, any 2-vs-2 partition — including the real one — produces mean differences roughly proportional to `σ²_g`, so high-variance genes rank at the top under any partition.

## Method

1. Per gene: `m_g = log1p(mean_g)`, `v_g = log1p(var_g)` from the DE expression layer.
2. Fit null-trend surface `φ̂(m, v) = E[log(1 + D²_null) | m, v]` via OLS on a 7-term tensor polynomial over the gene-shuffled null draws.
3. Homoscedastic null residual scale `σ̂_null`.
4. `R_g = log(1 + D²_g) − φ̂(m_g, v_g)`, `Z_g = R_g / σ̂_null`.
5. Apply kompot's existing 1-D local FDR to `max(0, Z_g)`. Below-null genes get `local_fdr ≈ 1`.

## Tal1 chimera validation

Post-hoc on `/export/chimera_tal1_kompot_ps01_*`:

|                               | raw top-20 | residual top-20 |
|-------------------------------|:----------:|:---------------:|
| Hematopoietic (Hbb-bh1, Itga2b, Lyl1, Stab1/2, Tfec, Ackr1, …) | 5          | **11**          |
| Imprinted (Cdkn1c, Phlda2, Grb10, Impact, Mcts2, Nnat, …)      | 12         | **0**           |
| Trend R² on Tal1 null                                           | —          | 0.88            |
| `σ̂_null` on Tal1 null                                          | —          | 0.48            |

Residual top-20 (in order): Hbb-bh1, Hba-x, Hbb-y, Stab2, Itga2b, Stab1, Tfec, Aqp8, Rplp0, Rpl41, Hba-a1, Slc22a18, Ackr1, Ushbp1, Erdr1, Rps18, Adora2a, Clec14a, Lyl1, Hba-a2. Matches the known Tal1 hematopoietic phenotype; the raw list was dominated by high-variance imprinted / X-linked genes.

## Design doc

Full derivation, evidence table, and limitations section (also destined for the methods supplement) live in the design note `reports/kompot_notebooks_private_2026-04-17_142500_residual-mahalanobis-flavor.md` of the companion `kompot_notebooks_private` workspace.

## What this does and does not do

**Does**
- Remove the strictly gene-level monotone dependence on `(mean, variance)` from the statistic before FDR calibration.
- Rank genes by how unusual their Mahalanobis is *conditional on* their `(m, v)`.
- Reuse kompot's existing GP fit / Mahalanobis / null-gene machinery; no GP changes.

**Does not**
- Remove manifold / cell-type structure. Genes that vary strongly between cell types will still have large Mahalanobis under any cell partition that splits cell-type mixtures.
- Fix the underlying experimental-design limitation of two biological replicates per condition. With sample fully confounded with condition, no statistic can separate condition-level biology from embryo-to-embryo variability in principle; the residual flavor correctly refuses to rank variability genes first but does not convert a 4-embryo design into a well-replicated one.

## Settings

```python
FDRSettings(
    mode="variance_stratified",               # opt-in; 'raw' is default
    null_trend_features=("log_mean", "log_var"),
    null_trend_model="poly3",                  # 7-term tensor polynomial (default)
    # or "poly3_mean_only" for a diagnostic mean-only model
)
```

## Test plan

- [x] 19 new tests in `tests/test_residualization.py` (feature extraction, null-trend fit, residualisation math, end-to-end through `kompot.de`, settings validation) — all pass.
- [x] Full FDR test suite (`test_fdr_utils`, `test_fdr_edge_cases`, `test_fdr_integration`, `test_model_settings`): 75 / 75 pass.
- [x] Full DE test suite (`test_differential`, `test_differential_expression_core`, `test_differential_expression_comprehensive`, `test_de_comprehensive_params`, `test_field_tracking`, `test_anndata_tracking`): 74 pass, 4 pre-existing skips.
- [x] Tal1 top-20 flip validated post-hoc (see table above).
- [ ] Upstream CI on PR branch.

## Files

- `kompot/residualization.py` — pure-numpy module with `compute_gene_features`, `fit_null_trend`, `residualize_mahalanobis`, `residual_local_fdr`
- `kompot/settings.py` — `FDRSettings` knobs: `mode`, `null_trend_features`, `null_trend_model`
- `kompot/anndata/_de_helpers.py` — `_compute_residual_fdr` helper; extended `_compute_fdr`, `_store_de_results`, `_build_field_mapping`, `_check_overwrites`
- `kompot/anndata/differential_expression.py` — plumbs settings through `de()` and legacy `compute_differential_expression()`
- `kompot/anndata/utils/field_tracking.py` — residual field-name keys
- `docs/source/variance_stratified_fdr.rst` — user-facing guide
- `docs/source/index.rst`, `README.md`, `CHANGELOG.md`
- `tests/test_residualization.py`